### PR TITLE
Refactoring to use DTOs as interface

### DIFF
--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/common/PerunController.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/common/PerunController.java
@@ -1,7 +1,7 @@
 package eu.bbmri.eric.csit.service.negotiator.api.controller.common;
 
-import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
-import eu.bbmri.eric.csit.service.negotiator.service.PersonService;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserDTO;
+import eu.bbmri.eric.csit.service.negotiator.service.PersonServiceImpl;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PerunController {
 
   @Autowired
-  private PersonService personService;
+  private PersonServiceImpl personService;
   @Autowired
   private ModelMapper modelMapper;
 
@@ -31,13 +31,9 @@ public class PerunController {
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
-  List<PerunUserRequest> createOrUpdate(
+  List<PerunUserDTO> createOrUpdate(
       @RequestBody @NotEmpty(message = "Perun Users Negotiation list cannot be empty.")
-      List<@Valid PerunUserRequest> perunUsersRequest) {
-
-    for (PerunUserRequest request : perunUsersRequest) {
-      personService.createOrUpdate(request);
-    }
-    return perunUsersRequest;
+      List<@Valid PerunUserDTO> request) {
+    return personService.createOrUpdate(request);
   }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v2/QueryV2Controller.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v2/QueryV2Controller.java
@@ -8,7 +8,7 @@ import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
 import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
-import eu.bbmri.eric.csit.service.negotiator.service.NegotiationService;
+import eu.bbmri.eric.csit.service.negotiator.service.NegotiationServiceImpl;
 import eu.bbmri.eric.csit.service.negotiator.service.RequestService;
 import java.net.URI;
 import java.util.HashMap;
@@ -30,13 +30,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class QueryV2Controller {
 
   private final RequestService requestService;
-  private final NegotiationService negotiationService;
+  private final NegotiationServiceImpl negotiationService;
   private final ModelMapper modelMapper;
   @Value("${negotiator.frontend-url}")
   private String FRONTEND_URL;
 
   public QueryV2Controller(
-      RequestService requestService, NegotiationService negotiationService,
+      RequestService requestService, NegotiationServiceImpl negotiationService,
       ModelMapper modelMapper) {
     this.requestService = requestService;
     this.negotiationService = negotiationService;
@@ -114,15 +114,14 @@ public class QueryV2Controller {
       String[] tokens = queryRequest.getToken().split("__search__");
       try {
         // If the negotiation was not found in V2, a new request was created
-        negotiationService.findById(tokens[0]);
+        negotiationService.exists(tokens[0]);
         created = false;
         if (tokens.length == 1) {
           requestEntity = requestService.create(v3Request);
-          negotiationService.addQueryToRequest(tokens[0], requestEntity);
+          negotiationService.addRequestToNegotiation(tokens[0], requestEntity);
         } else { // Updating an old request: the requestToken can be ignored
           requestEntity = requestService.update(tokens[1], v3Request);
         }
-
       } catch (EntityNotFoundException ex) {
         requestEntity = requestService.create(v3Request);
         created = true;

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/AccessCriteriaSetController.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/AccessCriteriaSetController.java
@@ -3,18 +3,16 @@ package eu.bbmri.eric.csit.service.negotiator.api.controller.v3;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSectionDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSetDTO;
-import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSection;
-import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSectionLink;
 import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSet;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Project;
-import eu.bbmri.eric.csit.service.negotiator.service.AccessCriteriaSetService;
+import eu.bbmri.eric.csit.service.negotiator.service.AccessCriteriaSetServiceImpl;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -23,55 +21,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v3")
 @CrossOrigin
 public class AccessCriteriaSetController {
-
-  private final AccessCriteriaSetService accessCriteriaSetService;
-
-  private final ModelMapper modelMapper;
-
-  public AccessCriteriaSetController(
-      AccessCriteriaSetService accessCriteriaSetService, ModelMapper modelMapper) {
-    this.accessCriteriaSetService = accessCriteriaSetService;
-    this.modelMapper = modelMapper;
-
-    TypeMap<AccessCriteriaSet, AccessCriteriaSetDTO> typeMap =
-        modelMapper.createTypeMap(AccessCriteriaSet.class, AccessCriteriaSetDTO.class);
-
-    Converter<Set<AccessCriteriaSection>, List<AccessCriteriaSectionDTO>> accessCriteriaConverter =
-        ffc -> formFieldConverter(ffc.getSource());
-    typeMap.addMappings(
-        mapper ->
-            mapper
-                .using(accessCriteriaConverter)
-                .map(AccessCriteriaSet::getSections, AccessCriteriaSetDTO::setSections));
-  }
-
-  private List<AccessCriteriaSectionDTO> formFieldConverter(Set<AccessCriteriaSection> sections) {
-    return sections.stream()
-        .map(
-            section -> {
-              List<AccessCriteriaDTO> accessCriteria = section.getAccessCriteriaSectionLink().stream().map(
-                  criteria -> new AccessCriteriaDTO(
-                      criteria.getAccessCriteria().getName(),
-                      criteria.getAccessCriteria().getLabel(),
-                      criteria.getAccessCriteria().getDescription(),
-                      criteria.getAccessCriteria().getType(),
-                      criteria.getRequired())
-              ).toList();
-              return new AccessCriteriaSectionDTO(
-                  section.getName(),
-                  section.getLabel(),
-                  section.getDescription(),
-                  accessCriteria);
-            }
-        )
-        .collect(Collectors.toList());
-  }
+  @Autowired
+  private AccessCriteriaSetServiceImpl accessCriteriaSetService;
 
   @GetMapping(value = "/access-criteria", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.OK)
   AccessCriteriaSetDTO search(@RequestParam String resourceId) {
-    AccessCriteriaSet accessCriteriaSet = accessCriteriaSetService.findByResourceEntityId(
-        resourceId);
-    return modelMapper.map(accessCriteriaSet, AccessCriteriaSetDTO.class);
+    return accessCriteriaSetService.findByResourceEntityId(resourceId);
   }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/DataSourceController.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/DataSourceController.java
@@ -5,7 +5,7 @@ import eu.bbmri.eric.csit.service.negotiator.api.dto.ValidationGroups.Update;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource;
-import eu.bbmri.eric.csit.service.negotiator.service.DataSourceService;
+import eu.bbmri.eric.csit.service.negotiator.service.DataSourceServiceImpl;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.modelmapper.ModelMapper;
@@ -28,20 +28,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class DataSourceController {
 
   @Autowired
-  private DataSourceService dataSourceService;
+  private DataSourceServiceImpl dataSourceService;
   @Autowired
   private ModelMapper modelMapper;
 
   @GetMapping("/data-sources")
   List<DataSourceDTO> list() {
-    return dataSourceService.findAll().stream()
-        .map(dataSource -> modelMapper.map(dataSource, DataSourceDTO.class))
-        .collect(Collectors.toList());
+    return dataSourceService.findAll();
   }
 
   @GetMapping("/data-sources/{id}")
   DataSourceDTO retrieve(@PathVariable Long id) {
-    return modelMapper.map(dataSourceService.getById(id), DataSourceDTO.class);
+    return dataSourceService.findById(id);
   }
 
   @PostMapping(
@@ -50,8 +48,7 @@ public class DataSourceController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
   DataSourceDTO add(@Validated(Create.class) @RequestBody DataSourceCreateDTO request) {
-    DataSource dataSourceEntity = dataSourceService.create(request);
-    return modelMapper.map(dataSourceEntity, DataSourceDTO.class);
+    return dataSourceService.create(request);
   }
 
   @PutMapping(
@@ -61,7 +58,6 @@ public class DataSourceController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   DataSourceDTO update(
       @PathVariable Long id, @Validated(Update.class) @RequestBody DataSourceCreateDTO request) {
-    DataSource dataSourceEntity = dataSourceService.update(id, request);
-    return modelMapper.map(dataSourceEntity, DataSourceDTO.class);
+    return dataSourceService.update(id, request);
   }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/NegotiationController.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/NegotiationController.java
@@ -1,81 +1,35 @@
 package eu.bbmri.eric.csit.service.negotiator.api.controller.v3;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationDTO;
-import eu.bbmri.eric.csit.service.negotiator.api.dto.person.PersonRoleDTO;
 import eu.bbmri.eric.csit.service.negotiator.configuration.auth.NegotiatorUserDetails;
 import eu.bbmri.eric.csit.service.negotiator.configuration.auth.NegotiatorUserDetailsService;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
-import eu.bbmri.eric.csit.service.negotiator.database.model.PersonNegotiationRole;
-import eu.bbmri.eric.csit.service.negotiator.service.NegotiationService;
+import eu.bbmri.eric.csit.service.negotiator.service.NegotiationServiceImpl;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import javax.validation.Valid;
-import org.modelmapper.Converter;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v3")
 @CrossOrigin
 public class NegotiationController {
 
-  private final NegotiationService negotiationService;
-
-  private final ModelMapper modelMapper;
-
-  public NegotiationController(NegotiationService negotiationService, ModelMapper modelMapper) {
-    this.negotiationService = negotiationService;
-    this.modelMapper = modelMapper;
-    TypeMap<Negotiation, NegotiationDTO> typeMap =
-        modelMapper.createTypeMap(Negotiation.class, NegotiationDTO.class);
-
-    Converter<Set<PersonNegotiationRole>, Set<PersonRoleDTO>> personsRoleConverter =
-        role -> personsRoleConverter(role.getSource());
-
-    typeMap.addMappings(
-        mapper ->
-            mapper
-                .using(personsRoleConverter)
-                .map(Negotiation::getPersons, NegotiationDTO::setPersons));
-
-    Converter<String, JsonNode> payloadConverter =
-        p -> {
-          try {
-            return payloadConverter(p.getSource());
-          } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);  // TODO: raise the correct exception
-          }
-        };
-
-    typeMap.addMappings(mapper -> mapper.using(payloadConverter)
-        .map(Negotiation::getPayload, NegotiationDTO::setPayload));
-
-  }
-
-  private Set<PersonRoleDTO> personsRoleConverter(Set<PersonNegotiationRole> personsRoles) {
-    return personsRoles.stream()
-        .map(
-            personRole ->
-                new PersonRoleDTO(
-                    personRole.getPerson().getAuthName(), personRole.getRole().getName()))
-        .collect(Collectors.toSet());
-  }
-
-  private JsonNode payloadConverter(String jsonPayload) throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
-    return mapper.readTree(jsonPayload);
-  }
-
+  @Autowired
+  private NegotiationServiceImpl negotiationService;
   /**
    * Create a negotiation
    */
@@ -85,8 +39,7 @@ public class NegotiationController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
   NegotiationDTO add(@Valid @RequestBody NegotiationCreateDTO request) {
-    Negotiation negotiationEntity = negotiationService.create(request, getCreatorId());
-    return modelMapper.map(negotiationEntity, NegotiationDTO.class);
+    return negotiationService.create(request, getCreatorId());
   }
 
   private Long getCreatorId() {
@@ -106,8 +59,7 @@ public class NegotiationController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   NegotiationDTO update(@Valid @PathVariable String id,
       @Valid @RequestBody NegotiationCreateDTO request) {
-    Negotiation negotiationEntity = negotiationService.update(id, request);
-    return modelMapper.map(negotiationEntity, NegotiationDTO.class);
+    return negotiationService.update(id, request);
   }
 
   @GetMapping("/negotiations")
@@ -115,27 +67,24 @@ public class NegotiationController {
       @RequestParam(required = false) String biobankId,
       @RequestParam(required = false) String collectionId,
       @RequestParam(required = false) String userRole) {
-    List<Negotiation> negotiations;
+    List<NegotiationDTO> negotiations;
     if (biobankId != null) {
       negotiations = negotiationService.findByBiobankId(biobankId);
     } else if (collectionId != null) {
       negotiations = negotiationService.findByCollectionId(collectionId);
     } else if (userRole != null) {
       negotiations = negotiationService.findByUserIdAndRole(
-              NegotiatorUserDetailsService.
-                      getCurrentlyAuthenticatedUserId(),
-              userRole);
+          NegotiatorUserDetailsService.
+              getCurrentlyAuthenticatedUserId(),
+          userRole);
     } else {
       negotiations = negotiationService.findAll();
     }
-    return negotiations.stream()
-        .map(request -> modelMapper.map(request, NegotiationDTO.class))
-        .collect(Collectors.toList());
+    return negotiations;
   }
 
   @GetMapping("/negotiations/{id}")
   NegotiationDTO retrieve(@Valid @PathVariable String id) {
-    Negotiation entity = negotiationService.findDetailedById(id);
-    return modelMapper.map(entity, NegotiationDTO.class);
+    return negotiationService.findById(id, true);
   }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/ProjectController.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/ProjectController.java
@@ -3,7 +3,7 @@ package eu.bbmri.eric.csit.service.negotiator.api.controller.v3;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Project;
-import eu.bbmri.eric.csit.service.negotiator.service.ProjectService;
+import eu.bbmri.eric.csit.service.negotiator.service.ProjectServiceImpl;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProjectController {
 
   @Autowired
-  private ProjectService projectService;
+  private ProjectServiceImpl projectService;
 
   @Autowired
   private ModelMapper modelMapper;
@@ -34,9 +34,7 @@ public class ProjectController {
   @GetMapping(value = "/projects", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.OK)
   List<ProjectDTO> list() {
-    return projectService.findAll().stream()
-        .map(project -> modelMapper.map(project, ProjectDTO.class))
-        .collect(Collectors.toList());
+    return projectService.findAll();
   }
 
   @GetMapping(value = "/projects/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -51,7 +49,6 @@ public class ProjectController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
   ProjectDTO add(@Valid @RequestBody ProjectCreateDTO request) {
-    Project projectEntity = projectService.create(request);
-    return modelMapper.map(projectEntity, ProjectDTO.class);
+    return projectService.create(request);
   }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/RequestController.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/controller/v3/RequestController.java
@@ -3,6 +3,7 @@ package eu.bbmri.eric.csit.service.negotiator.api.controller.v3;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Resource;
 import eu.bbmri.eric.csit.service.negotiator.service.RequestService;
@@ -45,25 +46,35 @@ public class RequestController {
     TypeMap<Request, RequestDTO> typeMap =
         modelMapper.createTypeMap(Request.class, RequestDTO.class);
 
-    Converter<Set<Resource>, Set<ResourceDTO>> queryResourceToResources =
-        q -> convertResourceToResources(q.getSource());
+    Converter<Set<Resource>, Set<ResourceDTO>> resourcesToResourcesDTO =
+        q -> convertResourcesToResourcesDTO(q.getSource());
     typeMap.addMappings(
         mapper ->
             mapper
-                .using(queryResourceToResources)
+                .using(resourcesToResourcesDTO)
                 .map(Request::getResources, RequestDTO::setResources));
 
-    Converter<String, String> queryToRedirectUrl = q -> convertIdToRedirectUrl(q.getSource());
+    Converter<String, String> requestToRedirectUrl = q -> convertIdToRedirectUrl(q.getSource());
     typeMap.addMappings(
         mapper ->
-            mapper.using(queryToRedirectUrl).map(Request::getId, RequestDTO::setRedirectUrl));
+            mapper.using(requestToRedirectUrl).map(Request::getId, RequestDTO::setRedirectUrl));
+
+    Converter<Negotiation, String> negotiationToNegotiationId = q -> convertNegotiationToNegotiationId(
+        q.getSource());
+    typeMap.addMappings(mapper ->
+        mapper.using(negotiationToNegotiationId)
+            .map(Request::getNegotiation, RequestDTO::setNegotiationId));
   }
 
-  private String convertIdToRedirectUrl(String queryId) {
-    return "%s/requests/%s".formatted(FRONTEND_URL, queryId);
+  private String convertNegotiationToNegotiationId(Negotiation negotiation) {
+    return negotiation != null ? negotiation.getId() : null;
   }
 
-  private Set<ResourceDTO> convertResourceToResources(Set<Resource> resources) {
+  private String convertIdToRedirectUrl(String requestId) {
+    return "%s/requests/%s".formatted(FRONTEND_URL, requestId);
+  }
+
+  private Set<ResourceDTO> convertResourcesToResourcesDTO(Set<Resource> resources) {
     Map<String, ResourceDTO> parents = new HashMap<>();
     resources.forEach(
         collection -> {

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/dto/perun/PerunUserDTO.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/dto/perun/PerunUserDTO.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PerunUserRequest {
+public class PerunUserDTO {
 
   @NotBlank(message = "Perun user negotiation organization cannot be null or empty.")
   private String organization;

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/dto/request/RequestDTO.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/api/dto/request/RequestDTO.java
@@ -31,4 +31,6 @@ public class RequestDTO {
 
   @NotNull
   private String redirectUrl;
+
+  private String negotiationId;
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/AccessCriteriaModelsMapper.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/AccessCriteriaModelsMapper.java
@@ -1,0 +1,61 @@
+package eu.bbmri.eric.csit.service.negotiator.configuration.mappers;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSectionDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSetDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSection;
+import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AccessCriteriaModelsMapper {
+
+  @Autowired
+  ModelMapper modelMapper;
+
+  @PostConstruct
+  void addMappings() {
+    TypeMap<AccessCriteriaSet, AccessCriteriaSetDTO> typeMap =
+        modelMapper.createTypeMap(AccessCriteriaSet.class, AccessCriteriaSetDTO.class);
+
+    Converter<Set<AccessCriteriaSection>, List<AccessCriteriaSectionDTO>> accessCriteriaConverter =
+        ffc -> formFieldConverter(ffc.getSource());
+
+    typeMap.addMappings(
+        mapper ->
+            mapper
+                .using(accessCriteriaConverter)
+                .map(AccessCriteriaSet::getSections, AccessCriteriaSetDTO::setSections));
+  }
+
+  private List<AccessCriteriaSectionDTO> formFieldConverter(Set<AccessCriteriaSection> sections) {
+    return sections.stream()
+        .map(
+            section -> {
+              List<AccessCriteriaDTO> accessCriteria = section.getAccessCriteriaSectionLink()
+                  .stream().map(
+                      criteria -> new AccessCriteriaDTO(
+                          criteria.getAccessCriteria().getName(),
+                          criteria.getAccessCriteria().getLabel(),
+                          criteria.getAccessCriteria().getDescription(),
+                          criteria.getAccessCriteria().getType(),
+                          criteria.getRequired())
+                  ).toList();
+              return new AccessCriteriaSectionDTO(
+                  section.getName(),
+                  section.getLabel(),
+                  section.getDescription(),
+                  accessCriteria);
+            }
+        )
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/NegotiationModelMapper.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/NegotiationModelMapper.java
@@ -1,0 +1,65 @@
+package eu.bbmri.eric.csit.service.negotiator.configuration.mappers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.person.PersonRoleDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
+import eu.bbmri.eric.csit.service.negotiator.database.model.PersonNegotiationRole;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NegotiationModelMapper {
+
+  @Autowired
+  ModelMapper modelMapper;
+
+  @PostConstruct
+  void addMappings() {
+    TypeMap<Negotiation, NegotiationDTO> typeMap =
+        modelMapper.createTypeMap(Negotiation.class, NegotiationDTO.class);
+
+    Converter<Set<PersonNegotiationRole>, Set<PersonRoleDTO>> personsRoleConverter =
+        role -> personsRoleConverter(role.getSource());
+
+    typeMap.addMappings(
+        mapper ->
+            mapper
+                .using(personsRoleConverter)
+                .map(Negotiation::getPersons, NegotiationDTO::setPersons));
+
+    Converter<String, JsonNode> payloadConverter =
+        p -> {
+          try {
+            return payloadConverter(p.getSource());
+          } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);  // TODO: raise the correct exception
+          }
+        };
+
+    typeMap.addMappings(mapper -> mapper.using(payloadConverter)
+        .map(Negotiation::getPayload, NegotiationDTO::setPayload));
+  }
+
+  private Set<PersonRoleDTO> personsRoleConverter(Set<PersonNegotiationRole> personsRoles) {
+    return personsRoles.stream()
+        .map(
+            personRole ->
+                new PersonRoleDTO(
+                    personRole.getPerson().getAuthName(), personRole.getRole().getName()))
+        .collect(Collectors.toSet());
+  }
+
+  private JsonNode payloadConverter(String jsonPayload) throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.readTree(jsonPayload);
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/PersonModelsMapper.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/PersonModelsMapper.java
@@ -1,6 +1,6 @@
 package eu.bbmri.eric.csit.service.negotiator.configuration.mappers;
 
-import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
 import javax.annotation.PostConstruct;
 import org.modelmapper.ModelMapper;
@@ -16,11 +16,11 @@ public class PersonModelsMapper {
 
   @PostConstruct
   public void setMappings() {
-    TypeMap<PerunUserRequest, Person> propertyMapper =
-        modelMapper.createTypeMap(PerunUserRequest.class, Person.class);
-    propertyMapper.addMapping(PerunUserRequest::getId, Person::setAuthSubject);
-    propertyMapper.addMapping(PerunUserRequest::getMail, Person::setAuthEmail);
-    propertyMapper.addMapping(PerunUserRequest::getDisplayName, Person::setAuthName);
-    propertyMapper.addMapping(PerunUserRequest::getOrganization, Person::setOrganization);
+    TypeMap<PerunUserDTO, Person> propertyMapper =
+        modelMapper.createTypeMap(PerunUserDTO.class, Person.class);
+    propertyMapper.addMapping(PerunUserDTO::getId, Person::setAuthSubject);
+    propertyMapper.addMapping(PerunUserDTO::getMail, Person::setAuthEmail);
+    propertyMapper.addMapping(PerunUserDTO::getDisplayName, Person::setAuthName);
+    propertyMapper.addMapping(PerunUserDTO::getOrganization, Person::setOrganization);
   }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/PersonModelsMapper.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/PersonModelsMapper.java
@@ -1,0 +1,26 @@
+package eu.bbmri.eric.csit.service.negotiator.configuration.mappers;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
+import javax.annotation.PostConstruct;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PersonModelsMapper {
+
+  @Autowired
+  ModelMapper modelMapper;
+
+  @PostConstruct
+  public void setMappings() {
+    TypeMap<PerunUserRequest, Person> propertyMapper =
+        modelMapper.createTypeMap(PerunUserRequest.class, Person.class);
+    propertyMapper.addMapping(PerunUserRequest::getId, Person::setAuthSubject);
+    propertyMapper.addMapping(PerunUserRequest::getMail, Person::setAuthEmail);
+    propertyMapper.addMapping(PerunUserRequest::getDisplayName, Person::setAuthName);
+    propertyMapper.addMapping(PerunUserRequest::getOrganization, Person::setOrganization);
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/RequestModelsMapper.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/configuration/mappers/RequestModelsMapper.java
@@ -1,0 +1,85 @@
+package eu.bbmri.eric.csit.service.negotiator.configuration.mappers;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Resource;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.PostConstruct;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RequestModelsMapper {
+
+  @Autowired
+  ModelMapper modelMapper;
+
+  @Value("${negotiator.frontend-url}")
+  private String FRONTEND_URL;
+
+  @PostConstruct
+  void addMappings(){
+    TypeMap<Request, RequestDTO> typeMap =
+        modelMapper.createTypeMap(Request.class, RequestDTO.class);
+
+    Converter<Set<Resource>, Set<ResourceDTO>> resourcesToResourcesDTO =
+        q -> convertResourcesToResourcesDTO(q.getSource());
+    typeMap.addMappings(
+        mapper ->
+            mapper
+                .using(resourcesToResourcesDTO)
+                .map(Request::getResources, RequestDTO::setResources));
+
+    Converter<String, String> requestToRedirectUrl = q -> convertIdToRedirectUrl(q.getSource());
+    typeMap.addMappings(
+        mapper ->
+            mapper.using(requestToRedirectUrl).map(Request::getId, RequestDTO::setRedirectUrl));
+
+    Converter<Negotiation, String> negotiationToNegotiationId = q -> convertNegotiationToNegotiationId(
+        q.getSource());
+    typeMap.addMappings(mapper ->
+        mapper.using(negotiationToNegotiationId)
+            .map(Request::getNegotiation, RequestDTO::setNegotiationId));
+  }
+
+  private String convertNegotiationToNegotiationId(Negotiation negotiation) {
+    return negotiation != null ? negotiation.getId() : null;
+  }
+
+  private String convertIdToRedirectUrl(String requestId) {
+    return "%s/requests/%s".formatted(FRONTEND_URL, requestId);
+  }
+
+  private Set<ResourceDTO> convertResourcesToResourcesDTO(Set<Resource> resources) {
+    Map<String, ResourceDTO> parents = new HashMap<>();
+    resources.forEach(
+        collection -> {
+          Resource parent = collection.getParent();
+          ResourceDTO parentResource;
+          if (parents.containsKey(parent.getSourceId())) {
+            parentResource = parents.get(parent.getSourceId());
+          } else {
+            parentResource = new ResourceDTO();
+            parentResource.setId(parent.getSourceId());
+            parentResource.setType("biobank");
+            parentResource.setChildren(new HashSet<>());
+            parents.put(parent.getSourceId(), parentResource);
+          }
+          ResourceDTO collectionResource = new ResourceDTO();
+          collectionResource.setType("collection");
+          collectionResource.setId(collection.getSourceId());
+          parentResource.getChildren().add(collectionResource);
+        });
+
+    return new HashSet<>(parents.values());
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/model/DataSource.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/model/DataSource.java
@@ -34,11 +34,9 @@ public class DataSource extends BaseEntity {
   private String apiUsername;
   @NotNull
   private String apiPassword;
-
   @Enumerated(EnumType.STRING)
   @NotNull
   private ApiType apiType;
-
   @NotNull
   private String resourceNetwork;
   @NotNull
@@ -47,6 +45,7 @@ public class DataSource extends BaseEntity {
   private String resourceCollection;
   @NotNull
   private Boolean syncActive;
+
   private String sourcePrefix;
   //  @OneToMany(mappedBy = "dataSource")
   //  private Set<User> users;

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/model/Request.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/model/Request.java
@@ -68,7 +68,7 @@ public class Request {
   private Set<Resource> resources;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "request_id")
+  @JoinColumn(name = "negotiation_id")
   @Exclude
   private Negotiation negotiation;
 

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/model/Resource.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/model/Resource.java
@@ -42,7 +42,6 @@ import lombok.ToString.Exclude;
     })
 public class Resource extends BaseEntity {
 
-  @NotNull
   private String name;
 
   @Column(columnDefinition = "VARCHAR(5000)")

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/repository/AccessCriteriaSetRepository.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/repository/AccessCriteriaSetRepository.java
@@ -1,6 +1,7 @@
 package eu.bbmri.eric.csit.service.negotiator.database.repository;
 
 import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSet;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -17,5 +18,5 @@ public interface AccessCriteriaSetRepository extends JpaRepository<AccessCriteri
               + "JOIN FETCH acs.accessCriteria ac "
               + "JOIN a.resources r "
               + "WHERE r.sourceId = :entityId")
-  AccessCriteriaSet findByResourceEntityId(String entityId);
+  Optional<AccessCriteriaSet> findByResourceEntityId(String entityId);
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/repository/NegotiationRepository.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/database/repository/NegotiationRepository.java
@@ -3,7 +3,6 @@ package eu.bbmri.eric.csit.service.negotiator.database.repository;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,12 +20,13 @@ public interface NegotiationRepository extends JpaRepository<Negotiation, String
   Optional<Negotiation> findDetailedById(String id);
 
   @Query(value = "SELECT DISTINCT r "
-          + "FROM Negotiation r "
-          + "JOIN FETCH r.persons pp "
-          + "JOIN FETCH pp.person p "
-          + "JOIN FETCH pp.role role "
-          + "where p.authSubject = :userId and role.name = :userRole")
-  List<Negotiation> findByUserIdAndRole(@Param("userId") String userId, @Param("userRole") String userRole );
+      + "FROM Negotiation r "
+      + "JOIN FETCH r.persons pp "
+      + "JOIN FETCH pp.person p "
+      + "JOIN FETCH pp.role role "
+      + "where p.authSubject = :userId and role.name = :userRole")
+  List<Negotiation> findByUserIdAndRole(@Param("userId") String userId,
+      @Param("userRole") String userRole);
 
   @Query(
       value =

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/AccessCriteriaSetService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/AccessCriteriaSetService.java
@@ -1,24 +1,9 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
-import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSet;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.AccessCriteriaSetRepository;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSetDTO;
 
-@Service
-public class AccessCriteriaSetService {
+public interface AccessCriteriaSetService {
 
-  @Autowired
-  private AccessCriteriaSetRepository accessCriteriaSetRepository;
+  AccessCriteriaSetDTO findByResourceEntityId(String resourceEntityId);
 
-  @Transactional
-  public AccessCriteriaSet findByResourceEntityId(String resourceEntityId) {
-    AccessCriteriaSet f = accessCriteriaSetRepository.findByResourceEntityId(resourceEntityId);
-    if (f == null) {
-      throw new EntityNotFoundException(resourceEntityId);
-    }
-    return f;
-  }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/AccessCriteriaSetServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/AccessCriteriaSetServiceImpl.java
@@ -1,0 +1,74 @@
+package eu.bbmri.eric.csit.service.negotiator.service;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSectionDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.access_criteria.AccessCriteriaSetDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSection;
+import eu.bbmri.eric.csit.service.negotiator.database.model.AccessCriteriaSet;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.AccessCriteriaSetRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AccessCriteriaSetServiceImpl implements AccessCriteriaSetService {
+
+  private final AccessCriteriaSetRepository accessCriteriaSetRepository;
+
+  private final ModelMapper modelMapper;
+
+  public AccessCriteriaSetServiceImpl(
+      AccessCriteriaSetRepository accessCriteriaSetRepository, ModelMapper modelMapper) {
+    this.accessCriteriaSetRepository = accessCriteriaSetRepository;
+    this.modelMapper = modelMapper;
+
+    TypeMap<AccessCriteriaSet, AccessCriteriaSetDTO> typeMap =
+        modelMapper.createTypeMap(AccessCriteriaSet.class, AccessCriteriaSetDTO.class);
+
+    Converter<Set<AccessCriteriaSection>, List<AccessCriteriaSectionDTO>> accessCriteriaConverter =
+        ffc -> formFieldConverter(ffc.getSource());
+    typeMap.addMappings(
+        mapper ->
+            mapper
+                .using(accessCriteriaConverter)
+                .map(AccessCriteriaSet::getSections, AccessCriteriaSetDTO::setSections));
+  }
+
+  private List<AccessCriteriaSectionDTO> formFieldConverter(Set<AccessCriteriaSection> sections) {
+    return sections.stream()
+        .map(
+            section -> {
+              List<AccessCriteriaDTO> accessCriteria = section.getAccessCriteriaSectionLink()
+                  .stream().map(
+                      criteria -> new AccessCriteriaDTO(
+                          criteria.getAccessCriteria().getName(),
+                          criteria.getAccessCriteria().getLabel(),
+                          criteria.getAccessCriteria().getDescription(),
+                          criteria.getAccessCriteria().getType(),
+                          criteria.getRequired())
+                  ).toList();
+              return new AccessCriteriaSectionDTO(
+                  section.getName(),
+                  section.getLabel(),
+                  section.getDescription(),
+                  accessCriteria);
+            }
+        )
+        .collect(Collectors.toList());
+  }
+
+
+  @Transactional
+  public AccessCriteriaSetDTO findByResourceEntityId(String resourceEntityId) {
+    Optional<AccessCriteriaSet> acs = accessCriteriaSetRepository.findByResourceEntityId(resourceEntityId);
+       acs.orElseThrow(() -> new EntityNotFoundException(resourceEntityId));
+    return modelMapper.map(acs, AccessCriteriaSetDTO.class);
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/AccessCriteriaSetServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/AccessCriteriaSetServiceImpl.java
@@ -28,42 +28,7 @@ public class AccessCriteriaSetServiceImpl implements AccessCriteriaSetService {
       AccessCriteriaSetRepository accessCriteriaSetRepository, ModelMapper modelMapper) {
     this.accessCriteriaSetRepository = accessCriteriaSetRepository;
     this.modelMapper = modelMapper;
-
-    TypeMap<AccessCriteriaSet, AccessCriteriaSetDTO> typeMap =
-        modelMapper.createTypeMap(AccessCriteriaSet.class, AccessCriteriaSetDTO.class);
-
-    Converter<Set<AccessCriteriaSection>, List<AccessCriteriaSectionDTO>> accessCriteriaConverter =
-        ffc -> formFieldConverter(ffc.getSource());
-    typeMap.addMappings(
-        mapper ->
-            mapper
-                .using(accessCriteriaConverter)
-                .map(AccessCriteriaSet::getSections, AccessCriteriaSetDTO::setSections));
   }
-
-  private List<AccessCriteriaSectionDTO> formFieldConverter(Set<AccessCriteriaSection> sections) {
-    return sections.stream()
-        .map(
-            section -> {
-              List<AccessCriteriaDTO> accessCriteria = section.getAccessCriteriaSectionLink()
-                  .stream().map(
-                      criteria -> new AccessCriteriaDTO(
-                          criteria.getAccessCriteria().getName(),
-                          criteria.getAccessCriteria().getLabel(),
-                          criteria.getAccessCriteria().getDescription(),
-                          criteria.getAccessCriteria().getType(),
-                          criteria.getRequired())
-                  ).toList();
-              return new AccessCriteriaSectionDTO(
-                  section.getName(),
-                  section.getLabel(),
-                  section.getDescription(),
-                  accessCriteria);
-            }
-        )
-        .collect(Collectors.toList());
-  }
-
 
   @Transactional
   public AccessCriteriaSetDTO findByResourceEntityId(String resourceEntityId) {

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/DataSourceService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/DataSourceService.java
@@ -1,48 +1,17 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
 import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceCreateDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.DataSourceRepository;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
 import java.util.List;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
 
-@org.springframework.stereotype.Service
-public class DataSourceService {
+public interface DataSourceService {
 
-  @Autowired
-  private DataSourceRepository dataSourceRepository;
+  DataSourceDTO create(DataSourceCreateDTO dataSourceRequest);
 
-  @Autowired
-  private ModelMapper modelMapper;
+  DataSourceDTO update(Long id, DataSourceCreateDTO dataSourceRequest);
 
-  public DataSource getById(Long id) {
-    return dataSourceRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
-  }
+  List<DataSourceDTO> findAll();
 
-  public List<DataSource> findAll() {
-    return dataSourceRepository.findAll();
-  }
-
-  public DataSource create(DataSourceCreateDTO dataSourceRequest) {
-    DataSource dataSourceEntity = modelMapper.map(dataSourceRequest, DataSource.class);
-    try {
-      return dataSourceRepository.save(dataSourceEntity);
-    } catch (DataIntegrityViolationException ex) {
-      throw new EntityNotStorableException();
-    }
-  }
-
-  public DataSource update(Long id, DataSourceCreateDTO dataSourceRequest) {
-    DataSource dataSourceEntity = getById(id);
-    modelMapper.map(dataSourceRequest, dataSourceEntity);
-    try {
-      return dataSourceRepository.save(dataSourceEntity);
-    } catch (DataIntegrityViolationException ex) {
-      throw new EntityNotStorableException();
-    }
-  }
+  DataSourceDTO findById(Long id);
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/DataSourceServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/DataSourceServiceImpl.java
@@ -1,0 +1,65 @@
+package eu.bbmri.eric.csit.service.negotiator.service;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceCreateDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.DataSourceRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DataSourceServiceImpl implements DataSourceService {
+
+  private final DataSourceRepository dataSourceRepository;
+
+  private final ModelMapper modelMapper;
+
+  @Autowired
+  public DataSourceServiceImpl(DataSourceRepository dataSourceRepository, ModelMapper modelMapper) {
+    this.dataSourceRepository = dataSourceRepository;
+    this.modelMapper = modelMapper;
+  }
+
+  private DataSource findEntityById(Long id) {
+    return dataSourceRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
+  }
+
+  @Transactional
+  public DataSourceDTO create(DataSourceCreateDTO dataSourceRequest) {
+    DataSource dataSourceEntity = modelMapper.map(dataSourceRequest, DataSource.class);
+    try {
+      return modelMapper.map(dataSourceRepository.save(dataSourceEntity), DataSourceDTO.class);
+    } catch (DataIntegrityViolationException ex) {
+      throw new EntityNotStorableException();
+    }
+  }
+
+  public DataSourceDTO update(Long id, DataSourceCreateDTO dataSourceRequest) {
+    DataSource dataSourceEntity = findEntityById(id);
+    modelMapper.map(dataSourceRequest, dataSourceEntity);
+    try {
+      return modelMapper.map(dataSourceRepository.save(dataSourceEntity), DataSourceDTO.class);
+    } catch (DataIntegrityViolationException ex) {
+      throw new EntityNotStorableException();
+    }
+  }
+
+  public DataSourceDTO findById(Long id) {
+    DataSource dataSource = findEntityById(id);
+    return modelMapper.map(dataSource, DataSourceDTO.class);
+  }
+
+  public List<DataSourceDTO> findAll() {
+    return dataSourceRepository.findAll().stream()
+        .map(dataSource -> modelMapper.map(dataSource, DataSourceDTO.class))
+        .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationService.java
@@ -1,250 +1,28 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
 import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationCreateDTO;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
-import eu.bbmri.eric.csit.service.negotiator.database.model.PersonNegotiationRole;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Role;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.NegotiationRepository;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.PersonRepository;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.RoleRepository;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.WrongRequestException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import lombok.extern.apachecommons.CommonsLog;
-import org.hibernate.exception.DataException;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@CommonsLog
-public class NegotiationService {
+public interface NegotiationService {
 
-  @Autowired
-  private NegotiationRepository negotiationRepository;
+  boolean exists(String negotiationId);
+  NegotiationDTO create(NegotiationCreateDTO negotiationBody, Long creatorId);
 
-  @Autowired
-  private RoleRepository roleRepository;
-  @Autowired
-  private PersonRepository personRepository;
-  @Autowired
-  private RequestService requestService;
-  @Autowired
-  private ModelMapper modelMapper;
+  NegotiationDTO update(String negotiationId, NegotiationCreateDTO negotiationBody);
 
-  private Set<Request> findQueries(Set<String> queriesId) {
-    Set<Request> queries;
-    try {
-      queries = requestService.findAllById(queriesId);
-    } catch (EntityNotFoundException ex) {
-      log.error("Some of the specified queries where not found");
-      throw new WrongRequestException("One or more of the specified queries do not exist");
-    }
-    return queries;
-  }
+  NegotiationDTO addRequestToNegotiation(String negotiationId, Request requestEntity);
 
+  List<NegotiationDTO> findAll();
 
-  /**
-   * Associates the Negotiation entity with other Entities and create the record
-   *
-   * @param negotiationEntity the Entity to save
-   * @param queriesId a Set of request ids to associate to the Negotiation
-   * @param creatorId the ID of the Person that creates the Negotiation (i.e., the authenticated
-   * Person that called the API)
-   * @return The created request
-   */
-  private Negotiation create(Negotiation negotiationEntity, Set<String> queriesId, Long creatorId) {
-    // Gets the Entities for the queries
-    log.debug("Getting request entities");
-    Set<Request> queries = findQueries(queriesId);
-    // Check if any request is already associated to a negotiation
-    if (queries.stream().anyMatch(query -> query.getNegotiation() != null)) {
-      log.error("One or more request object is already assigned to another negotiation");
-      throw new WrongRequestException(
-          "One or more request object is already assigned to another negotiation");
-    }
+  NegotiationDTO findById(String id, boolean includeDetails);
 
-    // Gets the Role entity. Since this is a new negotiation, the person is the CREATOR of the negotiation
-    Role role = roleRepository.findByName("CREATOR").orElseThrow(EntityNotStorableException::new);
+  // TODO: change byBiobankId
+  List<NegotiationDTO> findByBiobankId(String biobankId);
 
-    // Gets the person and associated roles
-    Person creator =
-        personRepository.findDetailedById(creatorId).orElseThrow(EntityNotStorableException::new);
+  // TODO: change to resouceId
+  List<NegotiationDTO> findByCollectionId(String collectionId);
 
-    // Ceates the association between the Person and the Negotiation
-    PersonNegotiationRole personRole = new PersonNegotiationRole(creator, negotiationEntity, role);
-
-    // Updates person and negotiation with the person role
-    creator.getRoles().add(personRole);
-    negotiationEntity.getPersons().add(personRole);
-
-    // Updates the bidirectional relationship between request and negotiation
-    negotiationEntity.setRequests(new HashSet<>(queries));
-    queries.forEach(
-        query -> {
-          query.setNegotiation(negotiationEntity);
-        });
-
-    try {
-      // Finally, save the negotiation. NB: it also cascades operations for other Queries,
-      // PersonNegotiationRole
-      return negotiationRepository.save(negotiationEntity);
-    } catch (DataException | DataIntegrityViolationException ex) {
-      log.error("Error while saving the Negotiation into db. Some db constraint violated");
-      throw new EntityNotStorableException();
-    }
-  }
-
-  /**
-   * Creates a Negotiation into the repository.
-   *
-   * @param request the NegotiationCreateDTO DTO sent from to the endpoint
-   * @param creatorId the ID of the Person that creates the Negotiation (i.e., the authenticated
-   * Person that called the API)
-   * @return the created Negotiation entity
-   */
-  @Transactional
-  public Negotiation create(NegotiationCreateDTO request, Long creatorId) {
-    Negotiation negotiationEntity = modelMapper.map(request, Negotiation.class);
-    return create(negotiationEntity, request.getRequests(), creatorId);
-  }
-
-//  /**
-//   * Creates a Negotiation and the Project it is part of into the repository.
-//   *
-//   * @param request the NegotiationCreateDTO DTO sent from to the endpoint. It must have also the
-//   * project data to create also the project
-//   * @param creatorId the ID of the Person that creates the Negotiation (i.e., the authenticated
-//   * Person that called the API)
-//   * @return the created Negotiation entity
-//   */
-//  @Transactional
-//  public Negotiation create(NegotiationCreateDTO request, Long creatorId) {
-//    if (request.getProject() == null) {
-//      throw new WrongRequestException("Missing project data");
-//    }
-//    Negotiation negotiationEntity = modelMapper.map(request, Negotiation.class);
-//    return create(negotiationEntity, request.getQueries(), creatorId);
-//  }
-
-  private Negotiation update(Negotiation negotiationEntity, NegotiationCreateDTO request) {
-    Set<Request> queries = findQueries(request.getRequests());
-
-    if (queries.stream()
-        .anyMatch(query -> query.getNegotiation() != null
-            && query.getNegotiation() != negotiationEntity)) {
-      throw new WrongRequestException(
-          "One or more request object is already assigned to another negotiation");
-    }
-
-    queries.forEach(
-        query -> {
-          query.setNegotiation(negotiationEntity);
-        });
-
-    negotiationEntity.setRequests(new HashSet<>(queries));
-
-    try {
-      negotiationRepository.save(negotiationEntity);
-      return negotiationEntity;
-    } catch (DataException | DataIntegrityViolationException ex) {
-      throw new EntityNotStorableException();
-    }
-  }
-
-  /**
-   * Updates the negotiation with the specified ID.
-   *
-   * @param id the id of the negotiation tu update
-   * @param request the NegotiationCreateDTO DTO with the new Negotiation data
-   * @return The updated Negotiation entity
-   */
-  @Transactional
-  public Negotiation update(String id, NegotiationCreateDTO request) {
-    Negotiation negotiationEntity = findDetailedById(id);
-    return update(negotiationEntity, request);
-  }
-
-  @Transactional
-  public Negotiation addQueryToRequest(String id, Request requestEntity) {
-    Negotiation negotiationEntity = findById(id);
-    negotiationEntity.getRequests().add(requestEntity);
-    requestEntity.setNegotiation(negotiationEntity);
-    try {
-      negotiationRepository.save(negotiationEntity);
-      return negotiationEntity;
-    } catch (DataIntegrityViolationException ex) {
-      throw new EntityNotStorableException();
-    }
-  }
-
-  /**
-   * Returns all negotiation in the repository
-   *
-   * @return the List of Negotiation entities
-   */
-  @Transactional
-  public List<Negotiation> findAll() {
-    return negotiationRepository.findAll();
-  }
-
-  /**
-   * Returns the Negotiation with the specified id if exists, otherwise it throws an exception
-   *
-   * @param id the id of the Negotiation to retrieve
-   * @return the Negotiation with specified id
-   */
-  @Transactional
-  public Negotiation findDetailedById(String id) throws EntityNotFoundException {
-    return negotiationRepository
-        .findDetailedById(id)
-        .orElseThrow(() -> new EntityNotFoundException(id));
-  }
-
-  /**
-   * Returns the Negotiation with the specified id if exists, otherwise it throws an exception
-   *
-   * @param id the id of the Negotiation to retrieve
-   * @return the Negotiation with specified id
-   */
-  @Transactional
-  public Negotiation findById(String id) throws EntityNotFoundException {
-    return negotiationRepository
-        .findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(id));
-  }
-
-  /**
-   * Returns a List of Negotiation entities filtered by biobank id
-   *
-   * @param biobankId the id in the data source of the biobank of the negotiation
-   * @return the List of Negotiation entities found
-   */
-  @Transactional
-  public List<Negotiation> findByBiobankId(String biobankId) {
-    return negotiationRepository.findByBiobankId(biobankId);
-  }
-
-  /**
-   * Returns a List of Negotiation entities filtered by biobank id
-   *
-   * @param collectionId the id in the data source of the biobank of the negotiation
-   * @return the List of Negotiation entities found
-   */
-  @Transactional
-  public List<Negotiation> findByCollectionId(String collectionId) {
-    return negotiationRepository.findByCollectionId(collectionId);
-  }
-
-  @Transactional
-  public List<Negotiation> findByUserIdAndRole(String userId, String userRole) {
-    return negotiationRepository.findByUserIdAndRole(userId, userRole);
-  }
+  List<NegotiationDTO> findByUserIdAndRole(String userId, String userRole);
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationService.java
@@ -2,17 +2,18 @@ package eu.bbmri.eric.csit.service.negotiator.service;
 
 import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationDTO;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestDTO;
 import java.util.List;
 
 public interface NegotiationService {
 
   boolean exists(String negotiationId);
+
   NegotiationDTO create(NegotiationCreateDTO negotiationBody, Long creatorId);
 
   NegotiationDTO update(String negotiationId, NegotiationCreateDTO negotiationBody);
 
-  NegotiationDTO addRequestToNegotiation(String negotiationId, Request requestEntity);
+  NegotiationDTO addRequestToNegotiation(String negotiationId, String requestId);
 
   List<NegotiationDTO> findAll();
 

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationServiceImpl.java
@@ -1,0 +1,346 @@
+package eu.bbmri.eric.csit.service.negotiator.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationCreateDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.person.PersonRoleDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
+import eu.bbmri.eric.csit.service.negotiator.database.model.PersonNegotiationRole;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Role;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.NegotiationRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.PersonRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.RoleRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.WrongRequestException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.apachecommons.CommonsLog;
+import org.hibernate.exception.DataException;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@CommonsLog
+public class NegotiationServiceImpl  implements NegotiationService {
+
+  private final NegotiationRepository negotiationRepository;
+  private final RoleRepository roleRepository;
+  private final PersonRepository personRepository;
+  private final RequestService requestService;
+  private final ModelMapper modelMapper;
+
+  public NegotiationServiceImpl(NegotiationRepository negotiationRepository,
+      RoleRepository roleRepository, PersonRepository personRepository,
+      RequestService requestService,
+      ModelMapper modelMapper) {
+
+    this.negotiationRepository = negotiationRepository;
+    this.roleRepository = roleRepository;
+    this.personRepository = personRepository;
+    this.requestService = requestService;
+    this.modelMapper = modelMapper;
+
+    TypeMap<Negotiation, NegotiationDTO> typeMap =
+        modelMapper.createTypeMap(Negotiation.class, NegotiationDTO.class);
+
+    Converter<Set<PersonNegotiationRole>, Set<PersonRoleDTO>> personsRoleConverter =
+        role -> personsRoleConverter(role.getSource());
+
+    typeMap.addMappings(
+        mapper ->
+            mapper
+                .using(personsRoleConverter)
+                .map(Negotiation::getPersons, NegotiationDTO::setPersons));
+
+    Converter<String, JsonNode> payloadConverter =
+        p -> {
+          try {
+            return payloadConverter(p.getSource());
+          } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);  // TODO: raise the correct exception
+          }
+        };
+
+    typeMap.addMappings(mapper -> mapper.using(payloadConverter)
+        .map(Negotiation::getPayload, NegotiationDTO::setPayload));
+
+  }
+
+  private Set<PersonRoleDTO> personsRoleConverter(Set<PersonNegotiationRole> personsRoles) {
+    Set<PersonRoleDTO> pr = personsRoles.stream()
+        .map(
+            personRole ->
+                new PersonRoleDTO(
+                    personRole.getPerson().getAuthName(), personRole.getRole().getName()))
+        .collect(Collectors.toSet());
+    return pr;
+  }
+
+  private JsonNode payloadConverter(String jsonPayload) throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.readTree(jsonPayload);
+  }
+
+  private Set<Request> findQueries(Set<String> queriesId) {
+    Set<Request> queries;
+    try {
+      queries = requestService.findAllById(queriesId);
+    } catch (EntityNotFoundException ex) {
+      log.error("Some of the specified queries where not found");
+      throw new WrongRequestException("One or more of the specified queries do not exist");
+    }
+    return queries;
+  }
+
+  /**
+   * Associates the Negotiation entity with other Entities and create the record
+   *
+   * @param negotiationEntity the Entity to save
+   * @param queriesId a Set of request ids to associate to the Negotiation
+   * @param creatorId the ID of the Person that creates the Negotiation (i.e., the authenticated
+   * Person that called the API)
+   * @return The created request
+   */
+  private Negotiation create(Negotiation negotiationEntity, Set<String> queriesId, Long creatorId) {
+    // Gets the Entities for the queries
+    log.debug("Getting request entities");
+    Set<Request> queries = findQueries(queriesId);
+    // Check if any request is already associated to a negotiation
+    if (queries.stream().anyMatch(query -> query.getNegotiation() != null)) {
+      log.error("One or more request object is already assigned to another negotiation");
+      throw new WrongRequestException(
+          "One or more request object is already assigned to another negotiation");
+    }
+
+    // Gets the Role entity. Since this is a new negotiation, the person is the CREATOR of the negotiation
+    Role role = roleRepository.findByName("CREATOR").orElseThrow(EntityNotStorableException::new);
+
+    // Gets the person and associated roles
+    Person creator =
+        personRepository.findDetailedById(creatorId).orElseThrow(EntityNotStorableException::new);
+
+    // Ceates the association between the Person and the Negotiation
+    PersonNegotiationRole personRole = new PersonNegotiationRole(creator, negotiationEntity, role);
+
+    // Updates person and negotiation with the person role
+    creator.getRoles().add(personRole);
+    negotiationEntity.getPersons().add(personRole);
+
+    // Updates the bidirectional relationship between request and negotiation
+    negotiationEntity.setRequests(new HashSet<>(queries));
+    queries.forEach(
+        query -> {
+          query.setNegotiation(negotiationEntity);
+        });
+
+    try {
+      // Finally, save the negotiation. NB: it also cascades operations for other Queries,
+      // PersonNegotiationRole
+      return negotiationRepository.save(negotiationEntity);
+    } catch (DataException | DataIntegrityViolationException ex) {
+      log.error("Error while saving the Negotiation into db. Some db constraint violated");
+      throw new EntityNotStorableException();
+    }
+  }
+
+  @Override
+  public boolean exists(String negotiationId) {
+    try {
+      findEntityById(negotiationId, false);
+      return true;
+    } catch (EntityNotFoundException ex) {
+      return false;
+    }
+  }
+
+  /**
+   * Creates a Negotiation into the repository.
+   *
+   * @param request the NegotiationCreateDTO DTO sent from to the endpoint
+   * @param creatorId the ID of the Person that creates the Negotiation (i.e., the authenticated
+   * Person that called the API)
+   * @return the created Negotiation entity
+   */
+  @Transactional
+  public NegotiationDTO create(NegotiationCreateDTO request, Long creatorId) {
+    Negotiation negotiationEntity = modelMapper.map(request, Negotiation.class);
+    // Gets the Entities for the queries
+    log.debug("Getting request entities");
+
+    Set<Request> queries = findQueries(request.getRequests());
+    // Check if any request is already associated to a negotiation
+    if (queries.stream().anyMatch(query -> query.getNegotiation() != null)) {
+      log.error("One or more request object is already assigned to another negotiation");
+      throw new WrongRequestException(
+          "One or more request object is already assigned to another negotiation");
+    }
+
+    // Gets the Role entity. Since this is a new negotiation, the person is the CREATOR of the negotiation
+    Role role = roleRepository.findByName("CREATOR").orElseThrow(EntityNotStorableException::new);
+
+    // Gets the person and associated roles
+    Person creator =
+        personRepository.findDetailedById(creatorId).orElseThrow(EntityNotStorableException::new);
+
+    // Ceates the association between the Person and the Negotiation
+    PersonNegotiationRole personRole = new PersonNegotiationRole(creator, negotiationEntity, role);
+
+    // Updates person and negotiation with the person role
+    creator.getRoles().add(personRole);
+    negotiationEntity.getPersons().add(personRole);
+
+    // Updates the bidirectional relationship between request and negotiation
+    negotiationEntity.setRequests(new HashSet<>(queries));
+    queries.forEach(
+        query -> {
+          query.setNegotiation(negotiationEntity);
+        });
+
+    try {
+      // Finally, save the negotiation. NB: it also cascades operations for other Requests,
+      // PersonNegotiationRole
+      Negotiation negotiation = negotiationRepository.save(negotiationEntity);
+      return modelMapper.map(negotiation, NegotiationDTO.class);
+    } catch (DataException | DataIntegrityViolationException ex) {
+      log.error("Error while saving the Negotiation into db. Some db constraint violated");
+      throw new EntityNotStorableException();
+    }
+  }
+
+  private NegotiationDTO update(Negotiation negotiationEntity, NegotiationCreateDTO request) {
+    Set<Request> queries = findQueries(request.getRequests());
+
+    if (queries.stream()
+        .anyMatch(query -> query.getNegotiation() != null
+            && query.getNegotiation() != negotiationEntity)) {
+      throw new WrongRequestException(
+          "One or more request object is already assigned to another negotiation");
+    }
+
+    queries.forEach(
+        query -> {
+          query.setNegotiation(negotiationEntity);
+        });
+
+    negotiationEntity.setRequests(new HashSet<>(queries));
+
+    try {
+      Negotiation negotiation = negotiationRepository.save(negotiationEntity);
+      return modelMapper.map(negotiation, NegotiationDTO.class);
+    } catch (DataException | DataIntegrityViolationException ex) {
+      throw new EntityNotStorableException();
+    }
+  }
+
+  /**
+   * Updates the negotiation with the specified ID.
+   *
+   * @param negotiationId the negotiationId of the negotiation tu update
+   * @param negotiationBody the NegotiationCreateDTO DTO with the new Negotiation data
+   * @return The updated Negotiation entity
+   */
+  @Transactional
+  public NegotiationDTO update(String negotiationId, NegotiationCreateDTO negotiationBody) {
+    Negotiation negotiationEntity = findEntityById(negotiationId, true);
+    return update(negotiationEntity, negotiationBody);
+  }
+
+  @Transactional
+  public NegotiationDTO addRequestToNegotiation(String negotiationId, Request requestEntity) {
+    Negotiation negotiationEntity = findEntityById(negotiationId, false);
+    negotiationEntity.getRequests().add(requestEntity);
+    requestEntity.setNegotiation(negotiationEntity);
+    try {
+      negotiationRepository.save(negotiationEntity);
+      return modelMapper.map(negotiationEntity, NegotiationDTO.class);
+    } catch (DataIntegrityViolationException ex) {
+      throw new EntityNotStorableException();
+    }
+  }
+
+  /**
+   * Returns all negotiation in the repository
+   *
+   * @return the List of Negotiation entities
+   */
+  @Transactional
+  public List<NegotiationDTO> findAll() {
+    List<Negotiation> negotiations = negotiationRepository.findAll();
+    return negotiations.stream()
+        .map(negotiation -> modelMapper.map(negotiation, NegotiationDTO.class))
+        .collect(Collectors.toList());
+  }
+
+  private Negotiation findEntityById(String negotiationId, boolean includeDetails) {
+    if (includeDetails) {
+      return negotiationRepository
+          .findDetailedById(negotiationId)
+          .orElseThrow(() -> new EntityNotFoundException(negotiationId));
+    } else {
+      return negotiationRepository
+          .findById(negotiationId)
+          .orElseThrow(() -> new EntityNotFoundException(negotiationId));
+    }
+  }
+
+  /**
+   * Returns the Negotiation with the specified negotiationId if exists, otherwise it throws an exception
+   *
+   * @param negotiationId the negotiationId of the Negotiation to retrieve
+   * @param includeDetails whether the negotiation returned include details
+   * @return the Negotiation with specified negotiationId
+   */
+  @Transactional
+  public NegotiationDTO findById(String negotiationId, boolean includeDetails) throws EntityNotFoundException {
+    Negotiation negotiation = findEntityById(negotiationId, includeDetails);
+    return modelMapper.map(negotiation, NegotiationDTO.class);
+  }
+
+  /**
+   * Returns a List of Negotiation entities filtered by biobank id
+   *
+   * @param biobankId the id in the data source of the biobank of the negotiation
+   * @return the List of Negotiation entities found
+   */
+  @Transactional
+  public List<NegotiationDTO> findByBiobankId(String biobankId) {
+    List<Negotiation> negotiations = negotiationRepository.findByBiobankId(biobankId);
+    return negotiations.stream()
+        .map(negotiation -> modelMapper.map(negotiation, NegotiationDTO.class))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a List of Negotiation entities filtered by biobank id
+   *
+   * @param collectionId the id in the data source of the biobank of the negotiation
+   * @return the List of Negotiation entities found
+   */
+  @Transactional
+  public List<NegotiationDTO> findByCollectionId(String collectionId) {
+    List<Negotiation> negotiations = negotiationRepository.findByCollectionId(collectionId);
+    return negotiations.stream()
+        .map(negotiation -> modelMapper.map(negotiation, NegotiationDTO.class))
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public List<NegotiationDTO> findByUserIdAndRole(String userId, String userRole) {
+    List<Negotiation> negotiations = negotiationRepository.findByUserIdAndRole(userId, userRole);
+    return negotiations.stream()
+        .map(negotiation -> modelMapper.map(negotiation, NegotiationDTO.class))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/PersonService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/PersonService.java
@@ -1,79 +1,15 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
-import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.PersonRepository;
 import java.util.List;
-import javax.annotation.PostConstruct;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeMap;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
-@Service
-public class PersonService {
+public interface PersonService {
 
-  @Autowired
-  private PersonRepository personRepository;
+  Person getById(Long id);
 
-  @Autowired
-  private ModelMapper modelMapper;
+  List<Person> findAll();
 
-  public Person getById(Long id) {
-    return personRepository
-        .findById(id)
-        .orElseThrow(
-            () ->
-                new ResponseStatusException(
-                    HttpStatus.NOT_FOUND, String.format("Person with id %d not found", id)));
-  }
-
-  public Person getByAuthSubject(String authSubject) {
-    return personRepository.findByAuthSubject(authSubject).orElse(null);
-  }
-
-  public List<Person> findAll() {
-    return personRepository.findAll();
-  }
-
-  public Person createOrUpdate(PerunUserRequest perunUserRequest) {
-
-    Person pers = getByAuthSubject(String.format("%s", perunUserRequest.getId()));
-    try {
-      if (pers == null) {
-        Person personEntity = modelMapper.map(perunUserRequest, Person.class);
-        return personRepository.save(personEntity);
-      }
-      modelMapper.map(perunUserRequest, pers);
-      return personRepository.save(pers);
-    } catch (DataIntegrityViolationException ex) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Some data sent cannot be saved");
-    }
-  }
-
-  //  public Person create(PerunUserRequest perunUserRequest) {
-  //
-  //    Person personEntity = modelMapper.map(perunUserRequest, Person.class);
-  //    try {
-  //      return personRepository.save(personEntity);
-  //    } catch (DataIntegrityViolationException ex) {
-  //      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Some data sent cannot be
-  // saved");
-  //    }
-  //  }
-  //
-  //  public Person update(Integer id, PerunUserRequest perunUserRequest) {
-  //    Person personEntity = getByAuthSubject(String.format("%s",id));
-  //    modelMapper.map(perunUserRequest, personEntity);
-  //    try {
-  //      return personRepository.save(personEntity);
-  //    } catch (DataIntegrityViolationException ex) {
-  //      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Some data sent cannot be
-  // saved");
-  //    }
-  //  }
+  List<PerunUserDTO> createOrUpdate(List<PerunUserDTO> request);
 
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/PersonService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/PersonService.java
@@ -22,16 +22,6 @@ public class PersonService {
   @Autowired
   private ModelMapper modelMapper;
 
-  @PostConstruct
-  public void setMappings() {
-    TypeMap<PerunUserRequest, Person> propertyMapper =
-        modelMapper.createTypeMap(PerunUserRequest.class, Person.class);
-    propertyMapper.addMapping(PerunUserRequest::getId, Person::setAuthSubject);
-    propertyMapper.addMapping(PerunUserRequest::getMail, Person::setAuthEmail);
-    propertyMapper.addMapping(PerunUserRequest::getDisplayName, Person::setAuthName);
-    propertyMapper.addMapping(PerunUserRequest::getOrganization, Person::setOrganization);
-  }
-
   public Person getById(Long id) {
     return personRepository
         .findById(id)

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/PersonServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/PersonServiceImpl.java
@@ -1,0 +1,81 @@
+package eu.bbmri.eric.csit.service.negotiator.service;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.PersonRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class PersonServiceImpl implements PersonService {
+
+  @Autowired
+  private PersonRepository personRepository;
+
+  @Autowired
+  private ModelMapper modelMapper;
+
+  public Person getById(Long id) {
+    return personRepository
+        .findById(id)
+        .orElseThrow(
+            () ->
+                new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, String.format("Person with id %d not found", id)));
+  }
+
+  private Person getByAuthSubject(String authSubject) {
+    return personRepository.findByAuthSubject(authSubject).orElse(null);
+  }
+
+  public List<Person> findAll() {
+    return personRepository.findAll();
+  }
+
+  public List<PerunUserDTO> createOrUpdate(List<PerunUserDTO> request) {
+    List<PerunUserDTO> users = new ArrayList<>();
+    for (PerunUserDTO user : request) {
+      Person person = getByAuthSubject(String.valueOf(user.getId()));
+      try {
+        if (person == null) {
+          person = modelMapper.map(user, Person.class);
+        } else {
+          modelMapper.map(user, person);
+        }
+        users.add(modelMapper.map(personRepository.save(person), PerunUserDTO.class));
+      } catch (DataIntegrityViolationException ex) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Some data sent cannot be saved");
+      }
+    }
+    return users;
+  }
+
+  //  public Person create(PerunUserDTO perunUserRequest) {
+  //
+  //    Person personEntity = modelMapper.map(perunUserRequest, Person.class);
+  //    try {
+  //      return personRepository.save(personEntity);
+  //    } catch (DataIntegrityViolationException ex) {
+  //      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Some data sent cannot be
+  // saved");
+  //    }
+  //  }
+  //
+  //  public Person update(Integer id, PerunUserDTO perunUserRequest) {
+  //    Person personEntity = getByAuthSubject(String.format("%s",id));
+  //    modelMapper.map(perunUserRequest, personEntity);
+  //    try {
+  //      return personRepository.save(personEntity);
+  //    } catch (DataIntegrityViolationException ex) {
+  //      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Some data sent cannot be
+  // saved");
+  //    }
+  //  }
+
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/ProjectService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/ProjectService.java
@@ -1,43 +1,15 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
 import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectCreateDTO;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Project;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.ProjectRepository;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectDTO;
 import java.util.List;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-public class ProjectService {
+public interface ProjectService {
 
-  @Autowired
-  private ProjectRepository projectRepository;
-  @Autowired
-  private ModelMapper modelMapper;
+  ProjectDTO create(ProjectCreateDTO projectRequest);
 
-  public Project create(ProjectCreateDTO projectRequest) {
-    Project projectEntity = modelMapper.map(projectRequest, Project.class);
-    try {
-      return projectRepository.save(projectEntity);
-    } catch (DataIntegrityViolationException ex) {
-      throw new EntityNotStorableException();
-    }
-  }
+  ProjectDTO findById(String id);
 
-  @Transactional
-  public Project findById(String id) {
-    return projectRepository
-        .findDetailedById(id)
-        .orElseThrow(() -> new EntityNotFoundException(id));
-  }
+  List<ProjectDTO> findAll();
 
-  @Transactional
-  public List<Project> findAll() {
-    return projectRepository.findAll();
-  }
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/ProjectServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/ProjectServiceImpl.java
@@ -1,0 +1,49 @@
+package eu.bbmri.eric.csit.service.negotiator.service;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectCreateDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Project;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.ProjectRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProjectServiceImpl implements ProjectService {
+
+  @Autowired
+  private ProjectRepository projectRepository;
+  @Autowired
+  private ModelMapper modelMapper;
+
+  public ProjectDTO create(ProjectCreateDTO projectRequest) {
+    Project projectEntity = modelMapper.map(projectRequest, Project.class);
+    try {
+      Project project = projectRepository.save(projectEntity);
+      return modelMapper.map(project, ProjectDTO.class);
+    } catch (DataIntegrityViolationException ex) {
+      throw new EntityNotStorableException();
+    }
+  }
+
+  @Transactional
+  public ProjectDTO findById(String id) {
+    Project project = projectRepository
+        .findDetailedById(id)
+        .orElseThrow(() -> new EntityNotFoundException(id));
+    return modelMapper.map(project, ProjectDTO.class);
+  }
+
+  @Transactional
+  public List<ProjectDTO> findAll() {
+    return projectRepository.findAll().stream()
+        .map(project -> modelMapper.map(project, ProjectDTO.class))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/RequestService.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/RequestService.java
@@ -1,123 +1,20 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestCreateDTO;
-import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
-import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Resource;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.DataSourceRepository;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.RequestRepository;
-import eu.bbmri.eric.csit.service.negotiator.database.repository.ResourceRepository;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
-import eu.bbmri.eric.csit.service.negotiator.exceptions.WrongRequestException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
-@org.springframework.stereotype.Service
-public class RequestService {
+public interface RequestService {
 
-  @Autowired
-  private RequestRepository requestRepository;
-  @Autowired
-  private ResourceRepository resourceRepository;
-  @Autowired
-  private DataSourceRepository dataSourceRepository;
-  @Autowired
-  private ModelMapper modelMapper;
+  RequestDTO create(RequestCreateDTO requestBody);
 
-  /**
-   * Checks that resources in input conforms to the hierarchy regitered in the negotiator, and if
-   * they do, add the leaf resources to the request
-   *
-   * @param resourceDTOs The List of Resources in the request negotiation
-   * @param requestEntity The Request Entity to save in the DB
-   */
-  private void checkAndSetResources(Set<ResourceDTO> resourceDTOs, Request requestEntity) {
-    Set<Resource> resourcesInQuery = new HashSet<>();
-    resourceDTOs.forEach(  // For each parent
-        resourceDTO -> {
-          // Gets the children
-          Set<ResourceDTO> childrenDTOs = resourceDTO.getChildren();
-          // Gets from the DB all the Resources with the ids of the children and parentId of the
-          // parent
-          Set<Resource> childrenResources =
-              resourceRepository.findBySourceIdInAndParentSourceId(
-                  childrenDTOs.stream().map(ResourceDTO::getId).collect(Collectors.toSet()),
-                  resourceDTO.getId());
-          // If the Resources in the DB are the same as the one in input, it means they are all correct
-          if (childrenResources.size() < childrenDTOs.size()) {
-            throw new WrongRequestException(
-                "Some of the specified resources were not found or the hierarchy was not correct");
-          } else {
-            resourcesInQuery.addAll(childrenResources);
-          }
-        }
-    );
-    requestEntity.setResources(resourcesInQuery);
-  }
+  List<RequestDTO> findAll();
 
-  /**
-   * Checks that the DataSource corresponding to the URL is present in the DB and adds it to the
-   * Request entity
-   *
-   * @param url the url of the DataSource in the incoming request
-   * @param requestEntity the Request entity to fill with the DataSource
-   */
-  private void checkAndSetDataSource(String url, Request requestEntity) {
-    URL dataSourceURL;
-    try {
-      dataSourceURL = new URL(url);
-    } catch (MalformedURLException e) {
-      throw new WrongRequestException("URL not valid");
-    }
-    DataSource dataSource =
-        dataSourceRepository
-            .findByUrl(
-                String.format("%s://%s", dataSourceURL.getProtocol(), dataSourceURL.getHost()))
-            .orElseThrow(() -> new WrongRequestException("Data source not found"));
-    requestEntity.setDataSource(dataSource);
-  }
+  RequestDTO findById(String id);
 
-  private Request saveQuery(RequestCreateDTO queryRequest, Request requestEntity) {
-    checkAndSetResources(queryRequest.getResources(), requestEntity);
-    checkAndSetDataSource(queryRequest.getUrl(), requestEntity);
-    requestEntity.setUrl(queryRequest.getUrl());
-    requestEntity.setHumanReadable(queryRequest.getHumanReadable());
-    return requestRepository.save(requestEntity);
-  }
+  Set<RequestDTO> findAllById(Set<String> ids);
 
-  @Transactional
-  public Request create(RequestCreateDTO queryRequest) {
-    Request requestEntity = new Request();
-    return saveQuery(queryRequest, requestEntity);
-  }
-
-  @Transactional(readOnly = true)
-  public List<Request> findAll() {
-    return requestRepository.findAll();
-  }
-
-  @Transactional(readOnly = true)
-  public Request findById(String id) {
-    return requestRepository.findDetailedById(id)
-        .orElseThrow(() -> new EntityNotFoundException(id));
-  }
-
-  public Set<Request> findAllById(Set<String> ids) {
-    return ids.stream().map(this::findById).collect(Collectors.toSet());
-  }
-
-  @Transactional
-  public Request update(String id, RequestCreateDTO queryRequest) {
-    Request requestEntity =
-        requestRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
-    return saveQuery(queryRequest, requestEntity);
-  }
+  RequestDTO update(String id, RequestCreateDTO requestBody);
 }

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/RequestServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/RequestServiceImpl.java
@@ -1,0 +1,200 @@
+package eu.bbmri.eric.csit.service.negotiator.service;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestCreateDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestDTO;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
+import eu.bbmri.eric.csit.service.negotiator.database.model.Resource;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.DataSourceRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.RequestRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.ResourceRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.WrongRequestException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RequestServiceImpl implements RequestService {
+
+  private RequestRepository requestRepository;
+
+  private ResourceRepository resourceRepository;
+
+  private DataSourceRepository dataSourceRepository;
+
+  private ModelMapper modelMapper;
+  @Value("${negotiator.frontend-url}")
+  private String FRONTEND_URL;
+
+  public RequestServiceImpl(RequestRepository requestRepository,
+      ResourceRepository resourceRepository, DataSourceRepository dataSourceRepository,
+      ModelMapper modelMapper) {
+    this.requestRepository = requestRepository;
+    this.resourceRepository = resourceRepository;
+    this.dataSourceRepository = dataSourceRepository;
+    this.modelMapper = modelMapper;
+
+    TypeMap<Request, RequestDTO> typeMap =
+        modelMapper.createTypeMap(Request.class, RequestDTO.class);
+
+    Converter<Set<Resource>, Set<ResourceDTO>> resourcesToResourcesDTO =
+        q -> convertResourcesToResourcesDTO(q.getSource());
+    typeMap.addMappings(
+        mapper ->
+            mapper
+                .using(resourcesToResourcesDTO)
+                .map(Request::getResources, RequestDTO::setResources));
+
+    Converter<String, String> requestToRedirectUrl = q -> convertIdToRedirectUrl(q.getSource());
+    typeMap.addMappings(
+        mapper ->
+            mapper.using(requestToRedirectUrl).map(Request::getId, RequestDTO::setRedirectUrl));
+
+    Converter<Negotiation, String> negotiationToNegotiationId = q -> convertNegotiationToNegotiationId(
+        q.getSource());
+    typeMap.addMappings(mapper ->
+        mapper.using(negotiationToNegotiationId)
+            .map(Request::getNegotiation, RequestDTO::setNegotiationId));
+  }
+
+  private String convertNegotiationToNegotiationId(Negotiation negotiation) {
+    return negotiation != null ? negotiation.getId() : null;
+  }
+
+  private String convertIdToRedirectUrl(String requestId) {
+    return "%s/requests/%s".formatted(FRONTEND_URL, requestId);
+  }
+
+  private Set<ResourceDTO> convertResourcesToResourcesDTO(Set<Resource> resources) {
+    Map<String, ResourceDTO> parents = new HashMap<>();
+    resources.forEach(
+        collection -> {
+          Resource parent = collection.getParent();
+          ResourceDTO parentResource;
+          if (parents.containsKey(parent.getSourceId())) {
+            parentResource = parents.get(parent.getSourceId());
+          } else {
+            parentResource = new ResourceDTO();
+            parentResource.setId(parent.getSourceId());
+            parentResource.setType("biobank");
+            parentResource.setChildren(new HashSet<>());
+            parents.put(parent.getSourceId(), parentResource);
+          }
+          ResourceDTO collectionResource = new ResourceDTO();
+          collectionResource.setType("collection");
+          collectionResource.setId(collection.getSourceId());
+          parentResource.getChildren().add(collectionResource);
+        });
+
+    return new HashSet<>(parents.values());
+  }
+
+  /**
+   * Checks that resources in input conforms to the hierarchy regitered in the negotiator, and if
+   * they do, add the leaf resources to the request
+   *
+   * @param resourceDTOs The List of Resources in the request negotiation
+   * @param requestEntity The Request Entity to save in the DB
+   */
+  private void checkAndSetResources(Set<ResourceDTO> resourceDTOs, Request requestEntity) {
+    Set<Resource> resourcesInQuery = new HashSet<>();
+    resourceDTOs.forEach(  // For each parent
+        resourceDTO -> {
+          // Gets the children
+          Set<ResourceDTO> childrenDTOs = resourceDTO.getChildren();
+          // Gets from the DB all the Resources with the ids of the children and parentId of the
+          // parent
+          Set<Resource> childrenResources =
+              resourceRepository.findBySourceIdInAndParentSourceId(
+                  childrenDTOs.stream().map(ResourceDTO::getId).collect(Collectors.toSet()),
+                  resourceDTO.getId());
+          // If the Resources in the DB are the same as the one in input, it means they are all correct
+          if (childrenResources.size() < childrenDTOs.size()) {
+            throw new WrongRequestException(
+                "Some of the specified resources were not found or the hierarchy was not correct");
+          } else {
+            resourcesInQuery.addAll(childrenResources);
+          }
+        }
+    );
+    requestEntity.setResources(resourcesInQuery);
+  }
+
+  /**
+   * Checks that the DataSource corresponding to the URL is present in the DB and adds it to the
+   * Request entity
+   *
+   * @param url the url of the DataSource in the incoming request
+   * @param requestEntity the Request entity to fill with the DataSource
+   */
+  private void checkAndSetDataSource(String url, Request requestEntity) {
+    URL dataSourceURL;
+    try {
+      dataSourceURL = new URL(url);
+    } catch (MalformedURLException e) {
+      throw new WrongRequestException("URL not valid");
+    }
+    DataSource dataSource =
+        dataSourceRepository
+            .findByUrl(
+                String.format("%s://%s", dataSourceURL.getProtocol(), dataSourceURL.getHost()))
+            .orElseThrow(() -> new WrongRequestException("Data source not found"));
+    requestEntity.setDataSource(dataSource);
+  }
+
+  private Request saveRequest(RequestCreateDTO queryRequest, Request requestEntity) {
+    checkAndSetResources(queryRequest.getResources(), requestEntity);
+    checkAndSetDataSource(queryRequest.getUrl(), requestEntity);
+    requestEntity.setUrl(queryRequest.getUrl());
+    requestEntity.setHumanReadable(queryRequest.getHumanReadable());
+    return requestRepository.save(requestEntity);
+  }
+
+  @Transactional
+  public RequestDTO create(RequestCreateDTO requestBody) {
+    Request request = new Request();
+    request = saveRequest(requestBody, request);
+    return modelMapper.map(request, RequestDTO.class);
+  }
+
+  @Transactional(readOnly = true)
+  public List<RequestDTO> findAll() {
+    List<Request> requests = requestRepository.findAll();
+    return requests.stream()
+        .map(request -> modelMapper.map(request, RequestDTO.class))
+        .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public RequestDTO findById(String id) {
+    Request request = requestRepository.findDetailedById(id)
+        .orElseThrow(() -> new EntityNotFoundException(id));
+    return modelMapper.map(request, RequestDTO.class);
+  }
+
+  public Set<RequestDTO> findAllById(Set<String> ids) {
+    return ids.stream().map(this::findById).collect(Collectors.toSet());
+  }
+
+  @Transactional
+  public RequestDTO update(String id, RequestCreateDTO queryRequest) {
+    Request requestEntity =
+        requestRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(id));
+    Request request = saveRequest(queryRequest, requestEntity);
+    return modelMapper.map(request, RequestDTO.class);
+  }
+}

--- a/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/RequestServiceImpl.java
+++ b/src/main/java/eu/bbmri/eric/csit/service/negotiator/service/RequestServiceImpl.java
@@ -4,7 +4,6 @@ import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource;
-import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Resource;
 import eu.bbmri.eric.csit.service.negotiator.database.repository.DataSourceRepository;
@@ -14,94 +13,26 @@ import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
 import eu.bbmri.eric.csit.service.negotiator.exceptions.WrongRequestException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeMap;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RequestServiceImpl implements RequestService {
 
+  @Autowired
   private RequestRepository requestRepository;
-
+  @Autowired
   private ResourceRepository resourceRepository;
-
+  @Autowired
   private DataSourceRepository dataSourceRepository;
-
+  @Autowired
   private ModelMapper modelMapper;
-  @Value("${negotiator.frontend-url}")
-  private String FRONTEND_URL;
-
-  public RequestServiceImpl(RequestRepository requestRepository,
-      ResourceRepository resourceRepository, DataSourceRepository dataSourceRepository,
-      ModelMapper modelMapper) {
-    this.requestRepository = requestRepository;
-    this.resourceRepository = resourceRepository;
-    this.dataSourceRepository = dataSourceRepository;
-    this.modelMapper = modelMapper;
-
-    TypeMap<Request, RequestDTO> typeMap =
-        modelMapper.createTypeMap(Request.class, RequestDTO.class);
-
-    Converter<Set<Resource>, Set<ResourceDTO>> resourcesToResourcesDTO =
-        q -> convertResourcesToResourcesDTO(q.getSource());
-    typeMap.addMappings(
-        mapper ->
-            mapper
-                .using(resourcesToResourcesDTO)
-                .map(Request::getResources, RequestDTO::setResources));
-
-    Converter<String, String> requestToRedirectUrl = q -> convertIdToRedirectUrl(q.getSource());
-    typeMap.addMappings(
-        mapper ->
-            mapper.using(requestToRedirectUrl).map(Request::getId, RequestDTO::setRedirectUrl));
-
-    Converter<Negotiation, String> negotiationToNegotiationId = q -> convertNegotiationToNegotiationId(
-        q.getSource());
-    typeMap.addMappings(mapper ->
-        mapper.using(negotiationToNegotiationId)
-            .map(Request::getNegotiation, RequestDTO::setNegotiationId));
-  }
-
-  private String convertNegotiationToNegotiationId(Negotiation negotiation) {
-    return negotiation != null ? negotiation.getId() : null;
-  }
-
-  private String convertIdToRedirectUrl(String requestId) {
-    return "%s/requests/%s".formatted(FRONTEND_URL, requestId);
-  }
-
-  private Set<ResourceDTO> convertResourcesToResourcesDTO(Set<Resource> resources) {
-    Map<String, ResourceDTO> parents = new HashMap<>();
-    resources.forEach(
-        collection -> {
-          Resource parent = collection.getParent();
-          ResourceDTO parentResource;
-          if (parents.containsKey(parent.getSourceId())) {
-            parentResource = parents.get(parent.getSourceId());
-          } else {
-            parentResource = new ResourceDTO();
-            parentResource.setId(parent.getSourceId());
-            parentResource.setType("biobank");
-            parentResource.setChildren(new HashSet<>());
-            parents.put(parent.getSourceId(), parentResource);
-          }
-          ResourceDTO collectionResource = new ResourceDTO();
-          collectionResource.setType("collection");
-          collectionResource.setId(collection.getSourceId());
-          parentResource.getChildren().add(collectionResource);
-        });
-
-    return new HashSet<>(parents.values());
-  }
 
   /**
    * Checks that resources in input conforms to the hierarchy regitered in the negotiator, and if

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -8,7 +8,7 @@ spring:
   sql:
     init:
       mode: always
-      platform: h2
+      platform: test
   jpa:
     hibernate:
       show-sql: true

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -1,0 +1,86 @@
+insert into role (id, name) values
+  (1, 'CREATOR'),
+  (2, 'ADMINISTRATOR'),
+  (3, 'MANAGER'),
+  (4, 'RESEARCHER');
+
+insert into data_source (url, api_username, api_password, api_type, api_url, description, name,
+   resource_biobank, resource_collection, resource_network, source_prefix, sync_active)
+values
+  ('http://datasource.dev', 'user', 'password', 'MOLGENIS', 'http://datasource.dev',
+   'Biobank Directory', 'Biobank Directory', 'directory_biobanks', 'directory_collections',
+   'directory_networks', 'source_prefix', 'false');
+
+insert into person (id, auth_email, auth_name, auth_subject, password, organization, person_image) values
+  (101, 'admin@negotiator.dev', 'admin', '1', '$2a$10$Kk29y.f7WeQeyym0X7YnvewDm3Gm/puTWGFniJvWen93C/f/6Bqey', 'BBMRI', null),
+  (102, 'directory@negotiator.dev', 'directory', '2', '$2a$10$iHi5bQ8nTRRF1bkiJfygkONgmABH1xNpLy2MZrHdusP.7.Rjpwk.i', 'BBMRI', null),
+  (103, 'perun@negotiator.dev', 'perun', '3', '$2a$10$RCBPPd3suXNB4vLSowDdUe5umkyZaDJCt.8DtG3xVidUhxWe2Woci', 'BBMRI', null),
+  (104, 'researcher@negotiator.dev', 'researcher', '4', '$2a$10$6Rc4eC5vo2IMGP0KUgrxIObq2SQoHTBKx8/o/Eyq1PpmzdBtTKj0u', 'BBMRI', null),
+  (105, 'manager@testbiobank.dev', 'test_biobank_manager', '5', null, 'Test Biobank', null),
+  (106, 'manager@testcollection.dev', 'test_collection_manager', '6', null, 'Test Collection', null),
+  (107, 'manager@testnetwork.dev', 'test_network_manager', '7', null, 'Test Network', null),
+  (108, 'adam.researcher@gmail.com', 'TheResearcher', '1000@bbmri.eu', null, 'BBMRI', null),
+  (109, 'taylor.biobanker@gmail.com', 'TheBiobanker', '1001@bbmri.eu', null, 'BBMRI', null);
+
+insert into authorities (person_id, authority) values
+  (101, 'ADMIN'),
+  (102, 'EXT_SERV'),
+  (103, 'PERUN_USER'),
+  (104, 'RESEARCHER'),
+  (108, 'RESEARCHER');
+
+insert into access_criteria_set (id, name) values (1, 'BBMRI Template');
+
+insert into access_criteria_section (id, name, label, description, access_criteria_set_id) values (1, 'project', 'Project', 'Provide information about your project', 1);
+insert into access_criteria_section (id, name, label, description, access_criteria_set_id) values (2, 'samples', 'Biosamples and Data Information', 'Provide information about the biosamples you want', 1);
+insert into access_criteria_section (id, name, label, description, access_criteria_set_id) values (3, 'ethics-vote', 'Ethics vote', 'Is ethics vote present in your project?', 1);
+
+insert into access_criteria (id, name, label, description, type) values (1, 'title', 'Title', 'Give a title', 'text');
+insert into access_criteria (id, name, label, description, type) values (2, 'description', 'Description', 'Give a description', 'textarea');
+insert into access_criteria (id, name, label, description, type) values (3, 'num-of-subjects', 'Number of subjects', 'Number of biosamples', 'number');
+insert into access_criteria (id, name, label, description, type) values (4, 'sample-type', 'Sample type(s)', 'Sample Type', 'text');
+insert into access_criteria (id, name, label, description, type) values (5, 'num-of-sample', 'Number of sample', 'Sample Type', 'text');
+insert into access_criteria (id, name, label, description, type) values (6, 'volume', 'Volume', 'Write the etchics vote', 'number');
+insert into access_criteria (id, name, label, description, type) values (7, 'ethics-vote', 'Ethics vote', 'Write the etchics vote', 'text');
+
+insert into access_criteria_section_link (access_criteria_section_id, access_criteria_id, ordering, required) values
+  (1, 1, 1, 'true'),
+  (1, 2, 2, 'false'),
+  (2, 3, 1, 'true'),
+  (2, 4, 2, 'false'),
+  (2, 5, 3, 'true'),
+  (2, 6, 4, 'false'),
+  (3, 7, 1, 'true');
+
+insert into resource (id, name, description, source_id, type, parent_id, data_source_id, access_criteria_set_id) values
+  (1, 'Test biobank #1', 'This is the first testing biobank', 'biobank:1', 'biobank' ,null, 1, 1),
+  (2, 'Test biobank #2', 'This is the second testing biobank', 'biobank:2', 'biobank', null, 1, 1),
+  (3, 'Test biobank #3', 'This is the third testing biobank', 'biobank:3', 'biobank', null, 1, 1),
+  (4, 'Test collection #1 of biobank #1', 'This is the first test collection of biobank 1', 'biobank:1:collection:1', 'collection', 1, 1, 1),
+  (5, 'Test collection #2 of biobank #1', 'This is the second test collection of biobank 1', 'biobank:1:collection:2', 'collection', 1, 1, 1),
+  (6, 'Test collection #1 of biobank #2', 'This is the first test collection of biobank 2', 'biobank:2:collection:1', 'collection', 2, 1, 1),
+  (7, 'Test collection #1 of biobank #3', 'This is the first test collection of biobank 3', 'biobank:3:collection:1', 'collection', 3, 1, 1),
+  (8, 'Test collection #2 of biobank #3', 'This is the second test collection of biobank 3', 'biobank:3:collection:2', 'collection', 3, 1, 1),
+  (9, 'Test collection #3 of biobank #3', 'This is the third test collection of biobank 3', 'biobank:3:collection:3', 'collection', 3, 1, 1);
+
+insert into person_resource_link (resource_id, person_id) values (1, 102), (4, 103);
+
+insert into negotiation (id, creation_date, modified_date, created_by, modified_by, payload) values
+  ('negotiation-1', '2023-04-12', '2023-04-12', 108, 108, '{"project":{"title":"title","description":"desc"},"samples":{"sample-type":"DNA","num-of-subjects": 10,"num-of-sample": "100","volume":3},"ethics-vote":{"ethics-vote":"My ethics"}}'),
+  ('negotiation-2', '2023-04-12', '2023-04-12', 108, 108, '{"project":{"title":"title","description":"desc"},"samples":{"sample-type":"Plasma","num-of-subjects": 10,"num-of-sample": "100","volume":3},"ethics-vote":{"ethics-vote":"My ethics"}}'),
+  ('negotiation-v2', '2023-04-12', '2023-04-12', 108, 108, '{"project":{"title":"Project 3","description":"Project 3 desc"},"samples":{"sample-type":"Blood","num-of-subjects": 5,"num-of-sample": "10","volume":4},"ethics-vote":{"ethics-vote":"My ethics"}}');
+
+insert into request (id, url, human_readable, data_source_id, negotiation_id) values
+  ('request-1', 'http://datasource.dev', '#1: No filters used', 1, 'negotiation-1'),
+  ('request-2', 'http://datasource.dev', '#1: DNA Samples', 1, null),
+  ('request-v2', 'http://datasource.dev', '#1: Blood Samples', 1, 'negotiation-v2');
+
+insert into request_resources_link (request_id, resource_id) values
+  ('request-1', 4),
+  ('request-2', 5),
+  ('request-2', 6),
+  ('request-v2', 7);
+
+insert into person_negotiation (negotiation_id, person_id, role_id) values ('negotiation-1', 108, 4);
+insert into person_negotiation (negotiation_id, person_id, role_id) values ('negotiation-2', 108, 4);
+insert into person_negotiation (negotiation_id, person_id, role_id) values ('negotiation-v2', 108, 4);

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/api/v3/RequestControllerTests.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/api/v3/RequestControllerTests.java
@@ -11,12 +11,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
 import eu.bbmri.eric.csit.service.negotiator.api.controller.v3.RequestController;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.RequestCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Negotiation;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Request;
 import eu.bbmri.eric.csit.service.negotiator.database.repository.RequestRepository;
-import eu.bbmri.eric.csit.service.negotiator.service.NegotiationService;
+import eu.bbmri.eric.csit.service.negotiator.service.NegotiationServiceImpl;
 import eu.bbmri.eric.csit.service.negotiator.service.RequestService;
 import java.util.Collections;
 import java.util.Optional;
@@ -54,7 +55,7 @@ public class RequestControllerTests {
   @Autowired
   private RequestService requestService;
   @Autowired
-  private NegotiationService negotiationService;
+  private NegotiationServiceImpl negotiationService;
   @Autowired
   private ModelMapper modelMapper;
 
@@ -214,7 +215,7 @@ public class RequestControllerTests {
   @Order(2)
   public void testGetAll_Ok_whenNegotiationIsAssigned() throws Exception {
     Request r = requestService.create(TestUtils.createRequest(false));
-    Negotiation n = negotiationService.create(
+    NegotiationDTO n = negotiationService.create(
         TestUtils.createNegotiation(false, Collections.singleton(r.getId())), 104L);
     mockMvc
         .perform(
@@ -260,7 +261,7 @@ public class RequestControllerTests {
   @Order(2)
   public void testGetById_Ok_whenNegotiationIsAssigned() throws Exception {
     Request r = requestService.create(TestUtils.createRequest(false));
-    Negotiation n = negotiationService.create(
+    NegotiationDTO n = negotiationService.create(
         TestUtils.createNegotiation(false, Collections.singleton(r.getId())), 104L);
     mockMvc
         .perform(

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/common/PerunControllerTests.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/common/PerunControllerTests.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.api.common;
+package eu.bbmri.eric.csit.service.negotiator.integration.api.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectCreateDTO;
-import eu.bbmri.eric.csit.service.negotiator.api.v3.TestUtils;
+import eu.bbmri.eric.csit.service.negotiator.integration.api.v3.TestUtils;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
 import eu.bbmri.eric.csit.service.negotiator.database.repository.PersonRepository;
 import java.util.List;

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/common/PerunControllerTests.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/common/PerunControllerTests.java
@@ -7,7 +7,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
-import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.integration.api.v3.TestUtils;
 import eu.bbmri.eric.csit.service.negotiator.database.model.Person;
@@ -82,7 +82,7 @@ public class PerunControllerTests {
   @Order(1)
   @Transactional
   public void testCreate_Ok() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     TestUtils.checkErrorResponse(
         mockMvc,
         HttpMethod.POST,
@@ -95,9 +95,9 @@ public class PerunControllerTests {
 
   @Test
   public void testCreate_BadRequest_WhenOrganizationMissingOrEmpty() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     // for one of the requests, set organization as null
-    PerunUserRequest badRequest = request.get(0);
+    PerunUserDTO badRequest = request.get(0);
     badRequest.setOrganization(null);
     request.set(0, badRequest);
     TestUtils.checkErrorResponse(
@@ -120,9 +120,9 @@ public class PerunControllerTests {
 
   @Test
   public void testCreate_BadRequest_WhenIdIsNull() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     // for one of the requests, set organization as null
-    PerunUserRequest badRequest = request.get(0);
+    PerunUserDTO badRequest = request.get(0);
     badRequest.setId(null);
     request.set(0, badRequest);
     TestUtils.checkErrorResponse(
@@ -136,9 +136,9 @@ public class PerunControllerTests {
 
   @Test
   public void testCreate_BadRequest_WhenDisplayNameMissingOrEmpty() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     // for one of the requests, set organization as null
-    PerunUserRequest badRequest = request.get(0);
+    PerunUserDTO badRequest = request.get(0);
     badRequest.setDisplayName(null);
     request.set(0, badRequest);
     TestUtils.checkErrorResponse(
@@ -161,9 +161,9 @@ public class PerunControllerTests {
 
   @Test
   public void testCreate_BadRequest_WhenStatusIsMissingOrEmpty() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     // for one of the requests, set organization as null
-    PerunUserRequest badRequest = request.get(0);
+    PerunUserDTO badRequest = request.get(0);
     badRequest.setStatus(null);
     request.set(0, badRequest);
     TestUtils.checkErrorResponse(
@@ -186,9 +186,9 @@ public class PerunControllerTests {
 
   @Test
   public void testCreate_BadRequest_WhenMailIsMissingOrEmpty() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     // for one of the requests, set organization as null
-    PerunUserRequest badRequest = request.get(0);
+    PerunUserDTO badRequest = request.get(0);
     badRequest.setMail(null);
     request.set(0, badRequest);
     TestUtils.checkErrorResponse(
@@ -213,9 +213,9 @@ public class PerunControllerTests {
   @Order(2)
   @Transactional
   public void testCreate_Ok_WhenIdentitiesAreMissingOrEmpty() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 2);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 2);
     // for one of the requests, set organization as null
-    PerunUserRequest badRequest = request.get(0);
+    PerunUserDTO badRequest = request.get(0);
     badRequest.setIdentities(null);
     request.set(0, badRequest);
     TestUtils.checkErrorResponse(
@@ -244,11 +244,11 @@ public class PerunControllerTests {
 
   @Test
   public void testUpdate_Ok() throws Exception {
-    List<PerunUserRequest> request = TestUtils.createPerunUserRequestList(false, 1);
+    List<PerunUserDTO> request = TestUtils.createPerunUserRequestList(false, 1);
     Person personEntity = modelMapper.map(request.get(0), Person.class);
     personRepository.save(personEntity);
     // Update by changing the organization in the negotiation
-    PerunUserRequest updateRequest = request.get(0);
+    PerunUserDTO updateRequest = request.get(0);
     String updatedOrganization = "UpdatedOrganization";
     updateRequest.setOrganization(updatedOrganization);
     request.set(0, updateRequest);

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/AccessCriteriaSetControllerTests.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/AccessCriteriaSetControllerTests.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.api.v3;
+package eu.bbmri.eric.csit.service.negotiator.integration.api.v3;
 
 import static org.hamcrest.core.Is.is;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/DataSourceControllerTests.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/DataSourceControllerTests.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.api.v3;
+package eu.bbmri.eric.csit.service.negotiator.integration.api.v3;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/ProjectControllerTests.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/ProjectControllerTests.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.api.v3;
+package eu.bbmri.eric.csit.service.negotiator.integration.api.v3;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/TestUtils.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/TestUtils.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.api.v3;
+package eu.bbmri.eric.csit.service.negotiator.integration.api.v3;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -16,7 +16,6 @@ import eu.bbmri.eric.csit.service.negotiator.api.dto.request.ResourceDTO;
 import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource.ApiType;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -120,19 +119,15 @@ public class TestUtils {
         .build();
   }
 
-  public static QueryCreateV2DTO createQueryV2Request(boolean update) {
-    String suffix = update ? "u" : "";
-    String collectionId = update ? QUERY_COLLECTION_2_ID : QUERY_COLLECTION_1_ID;
-    String biobankId = update ? QUERY_BIOBANK_2_ID : QUERY_BIOBANK_1_ID;
-
+  public static QueryCreateV2DTO createQueryV2Request() {;
     CollectionV2DTO collection =
         CollectionV2DTO.builder()
-            .collectionId(collectionId)
-            .biobankId(biobankId)
+            .collectionId(QUERY_COLLECTION_1_ID)
+            .biobankId(QUERY_BIOBANK_1_ID)
             .build();
 
     return QueryCreateV2DTO.builder()
-        .humanReadable(String.format("%s%s", QUERY_HUMAN_READABLE, suffix))
+        .humanReadable(QUERY_HUMAN_READABLE)
         .url(QUERY_URL)
         .collections(Set.of(collection))
         .build();
@@ -165,25 +160,24 @@ public class TestUtils {
     return perunUserRequestList;
   }
 
-  public static NegotiationCreateDTO createNegotiation(
-      boolean update, Set<String> requestsId) throws IOException {
+  public static NegotiationCreateDTO createNegotiation(Set<String> requestsId) throws IOException {
     String payload = """
-        {
-          "project": {
-            "title": "Title",
-            "description": "Description"
-          },
-          "samples": {
-            "sample-type": "DNA",
-            "num-of-subjects": 10,
-            "num-of-samples": 20,
-            "volume-per-sample": 5
-          },
-          "ethics-vote": {
-            "ethics-vote": "My ethic vote"
-          }
-        }
-    """;
+            {
+              "project": {
+                "title": "Title",
+                "description": "Description"
+              },
+              "samples": {
+                "sample-type": "DNA",
+                "num-of-subjects": 10,
+                "num-of-samples": 20,
+                "volume-per-sample": 5
+              },
+              "ethics-vote": {
+                "ethics-vote": "My ethic vote"
+              }
+            }
+        """;
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonPayload = mapper.readTree(payload);
 

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/TestUtils.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/integration/api/v3/TestUtils.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.negotiation.NegotiationCreateDTO;
-import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserRequest;
+import eu.bbmri.eric.csit.service.negotiator.api.dto.perun.PerunUserDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.project.ProjectCreateDTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.CollectionV2DTO;
 import eu.bbmri.eric.csit.service.negotiator.api.dto.request.QueryCreateV2DTO;
@@ -141,13 +141,13 @@ public class TestUtils {
         .build();
   }
 
-  public static List<PerunUserRequest> createPerunUserRequestList(boolean update, int size) {
+  public static List<PerunUserDTO> createPerunUserRequestList(boolean update, int size) {
     String suffix = update ? "u" : "";
-    List<PerunUserRequest> perunUserRequestList = new ArrayList<>();
+    List<PerunUserDTO> perunUserDTOList = new ArrayList<>();
 
     for (int i = 0; i < size; i++) {
-      PerunUserRequest request =
-          PerunUserRequest.builder()
+      PerunUserDTO request =
+          PerunUserDTO.builder()
               .id(PERUN_USER_ID + i)
               .displayName(String.format("%s_%s", PERUN_USER_DISPLAY_NAME, i))
               .organization(String.format("%s_%s", PERUN_USER_ORGANIZATION, i))
@@ -155,9 +155,9 @@ public class TestUtils {
               .mail(String.format("%s_%s", PERUN_USER_MAIL, i))
               .identities(PERUN_USER_IDENTITIES)
               .build();
-      perunUserRequestList.add(request);
+      perunUserDTOList.add(request);
     }
-    return perunUserRequestList;
+    return perunUserDTOList;
   }
 
   public static NegotiationCreateDTO createNegotiation(Set<String> requestsId) throws IOException {

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/service/NegotiationServiceTest.java
@@ -1,37 +1,52 @@
 package eu.bbmri.eric.csit.service.negotiator.service;
 
-import eu.bbmri.eric.csit.service.negotiator.database.repository.NegotiationRepository;
-import org.aspectj.lang.annotation.Before;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.annotation.Resource;
-
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.NegotiationRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = NegotiatorApplication.class)
+@ActiveProfiles("test")
 public class NegotiationServiceTest {
+    private AutoCloseable closeable;
 
     @Mock
     NegotiationRepository negotiationRepository;
-    @InjectMocks
-    @Resource
-    NegotiationService negotiationService;
+
+    @Autowired
+    NegotiationServiceImpl negotiationService;
 
     @BeforeEach
     void beforeAll() {
-        MockitoAnnotations.openMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void afterAll() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void testExistIsFalse_WhenNegotiationIsNotFound() {
+        when(negotiationRepository.findById(any())).thenThrow(EntityNotFoundException.class);
+        assertFalse(negotiationService.exists("unknown"));
     }
 
     @Test
     public void findByUserIDAndRoleReturnsNullForFakeParameters() {
         when(negotiationRepository.findByUserIdAndRole(any(), any())).thenReturn(null);
-        assertNull(negotiationService.findByUserIdAndRole("fakeID", "fakeRole"));
+        assertTrue(negotiationService.findByUserIdAndRole("fakeID", "fakeRole").isEmpty());
     }
 }

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/AccessCriteriaSetServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/AccessCriteriaSetServiceTest.java
@@ -1,0 +1,50 @@
+package eu.bbmri.eric.csit.service.negotiator.unit.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.AccessCriteriaSetRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import eu.bbmri.eric.csit.service.negotiator.service.AccessCriteriaSetServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = NegotiatorApplication.class)
+@ActiveProfiles("test")
+public class AccessCriteriaSetServiceTest {
+
+  @Mock
+  AccessCriteriaSetRepository accessCriteriaSetRepository;
+
+  @Autowired
+  AccessCriteriaSetServiceImpl accessCriteriaSetService;
+
+  private AutoCloseable closeable;
+
+  @BeforeEach
+  void beforeAll() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void afterAll() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  void testRaiseException_whenAccessCriteriaNotFound() {
+    when(accessCriteriaSetRepository.findByResourceEntityId(any())).thenReturn(Optional.empty());
+    assertThrows(EntityNotFoundException.class,
+        () -> accessCriteriaSetService.findByResourceEntityId("aResourceId"));
+
+  }
+}

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/AccessCriteriaSetServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/AccessCriteriaSetServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
 import eu.bbmri.eric.csit.service.negotiator.database.repository.AccessCriteriaSetRepository;
 import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
 import eu.bbmri.eric.csit.service.negotiator.service.AccessCriteriaSetServiceImpl;
@@ -12,26 +11,26 @@ import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.modelmapper.ModelMapper;
 
-@SpringBootTest(classes = NegotiatorApplication.class)
-@ActiveProfiles("test")
 public class AccessCriteriaSetServiceTest {
 
   @Mock
   AccessCriteriaSetRepository accessCriteriaSetRepository;
 
-  @Autowired
-  AccessCriteriaSetServiceImpl accessCriteriaSetService;
+  @Mock
+  ModelMapper modelMapper;
+
+  @InjectMocks
+  AccessCriteriaSetServiceImpl service;
 
   private AutoCloseable closeable;
 
   @BeforeEach
-  void beforeAll() {
+  void before() {
     closeable = MockitoAnnotations.openMocks(this);
   }
 
@@ -44,7 +43,7 @@ public class AccessCriteriaSetServiceTest {
   void testRaiseException_whenAccessCriteriaNotFound() {
     when(accessCriteriaSetRepository.findByResourceEntityId(any())).thenReturn(Optional.empty());
     assertThrows(EntityNotFoundException.class,
-        () -> accessCriteriaSetService.findByResourceEntityId("aResourceId"));
+        () -> service.findByResourceEntityId("aResourceId"));
 
   }
 }

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/DataSourceServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/DataSourceServiceTest.java
@@ -1,0 +1,68 @@
+package eu.bbmri.eric.csit.service.negotiator.unit.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import eu.bbmri.eric.csit.service.negotiator.api.dto.datasource.DataSourceCreateDTO;
+import eu.bbmri.eric.csit.service.negotiator.database.model.DataSource.ApiType;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.DataSourceRepository;
+import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotStorableException;
+import eu.bbmri.eric.csit.service.negotiator.service.DataSourceServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class DataSourceServiceTest {
+
+  @Mock
+  DataSourceRepository dataSourceRepository;
+
+  @Mock
+  ModelMapper modelMapper;
+
+  @InjectMocks
+  DataSourceServiceImpl service;
+
+
+  private AutoCloseable closeable;
+
+  @BeforeEach
+  void before() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void after() throws Exception {
+    closeable.close();
+  }
+
+  private DataSourceCreateDTO getTestDTO() {
+    return DataSourceCreateDTO.builder()
+        .description("Test Data Source")
+        .name("Name of the data source")
+        .url("http://datasource")
+        .apiUrl("http://datasource/api")
+        .apiType(ApiType.MOLGENIS)
+        .apiUsername("test")
+        .apiPassword("test")
+        .resourceNetwork("test_ds_network")
+        .resourceBiobank("test_ds_biobank")
+        .resourceCollection("test_ds_collection")
+        .syncActive(true)
+        .sourcePrefix("prefix")
+        .build();
+  }
+
+  @Test
+  public void testCreateRaiseException_WhenDBFails() {
+    DataSourceCreateDTO dto = getTestDTO();
+    when(dataSourceRepository.save(any())).thenThrow(DataIntegrityViolationException.class);
+    assertThrows(EntityNotStorableException.class, () -> service.create(dto));
+  }
+}

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/NegotiationServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/NegotiationServiceTest.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.service;
+package eu.bbmri.eric.csit.service.negotiator.unit.service;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
 import eu.bbmri.eric.csit.service.negotiator.database.repository.NegotiationRepository;
 import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
+import eu.bbmri.eric.csit.service.negotiator.service.NegotiationServiceImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/NegotiationServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/NegotiationServiceTest.java
@@ -5,49 +5,59 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import eu.bbmri.eric.csit.service.negotiator.NegotiatorApplication;
 import eu.bbmri.eric.csit.service.negotiator.database.repository.NegotiationRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.PersonRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.RequestRepository;
+import eu.bbmri.eric.csit.service.negotiator.database.repository.RoleRepository;
 import eu.bbmri.eric.csit.service.negotiator.exceptions.EntityNotFoundException;
 import eu.bbmri.eric.csit.service.negotiator.service.NegotiationServiceImpl;
+import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = NegotiatorApplication.class)
-@ActiveProfiles("test")
 public class NegotiationServiceTest {
-    private AutoCloseable closeable;
 
-    @Mock
-    NegotiationRepository negotiationRepository;
+  @Mock
+  NegotiationRepository negotiationRepository;
+  @Mock
+  RoleRepository roleRepository;
+  @Mock
+  PersonRepository personRepository;
+  @Mock
+  RequestRepository requestRepository;
+  @Mock
+  ModelMapper modelMapper;
+  @Autowired
+  @InjectMocks
+  NegotiationServiceImpl negotiationService;
+  private AutoCloseable closeable;
 
-    @Autowired
-    NegotiationServiceImpl negotiationService;
+  @BeforeEach
+  void before() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
 
-    @BeforeEach
-    void beforeAll() {
-        closeable = MockitoAnnotations.openMocks(this);
-    }
+  @AfterEach
+  void after() throws Exception {
+    closeable.close();
+  }
 
-    @AfterEach
-    void afterAll() throws Exception {
-        closeable.close();
-    }
+  @Test
+  public void test_Exist_IsFalse_WhenNegotiationIsNotFound() {
+    when(negotiationRepository.findById(any())).thenThrow(EntityNotFoundException.class);
+    assertFalse(negotiationService.exists("unknown"));
+  }
 
-    @Test
-    public void testExistIsFalse_WhenNegotiationIsNotFound() {
-        when(negotiationRepository.findById(any())).thenThrow(EntityNotFoundException.class);
-        assertFalse(negotiationService.exists("unknown"));
-    }
-
-    @Test
-    public void findByUserIDAndRoleReturnsNullForFakeParameters() {
-        when(negotiationRepository.findByUserIdAndRole(any(), any())).thenReturn(null);
-        assertTrue(negotiationService.findByUserIdAndRole("fakeID", "fakeRole").isEmpty());
-    }
+  @Test
+  public void test_FindByUserAndRole_ReturnsEmptyList_whenNotFound() {
+    when(negotiationRepository.findByUserIdAndRole(any(), any())).thenReturn(
+        Collections.emptyList());
+    assertTrue(negotiationService.findByUserIdAndRole("fakeID", "fakeRole").isEmpty());
+  }
 }

--- a/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/NegotiatorUserDetailServiceTest.java
+++ b/src/test/java/eu/bbmri/eric/csit/service/negotiator/unit/service/NegotiatorUserDetailServiceTest.java
@@ -1,4 +1,4 @@
-package eu.bbmri.eric.csit.service.negotiator.service;
+package eu.bbmri.eric.csit.service.negotiator.unit.service;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
PR that refactors interface between Controllers and Services.
Now the services accept and return DTOS.
Other changes:
 - Added interfaces for Services
 - Added unit test structure with very few unit test
 - Split tests between unit and integration and moved all the old test into integration
 - Created in the configuration some classes to map between data models. Before that, the mappers were inside the Services classes. Now they are all gathered in a single package
