### PR TITLE
fix: Preserves h2 connection to close and lost in memory table data

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:negotiator;INIT=RUNSCRIPT FROM 'classpath:dev/init.sql'
+    url: jdbc:h2:mem:negotiator;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:dev/init.sql'
     username: negotiator
     password: negotiator
     initialize: true


### PR DESCRIPTION
This PR preserves the H2 in memory database to lose "PERSON" table and cause the crash of the application. Usually, it happens when the last opened DB connection is closed: when it happens, the H2 drops the table because it has not persistence. The added parameter allows to keep the connection alive, until the Virtual Machine is up.